### PR TITLE
允许自定义是否采用频道流模式

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -139,6 +139,16 @@ const (
 )
 
 const (
+	ChannelAllowNonStreamEnabled  = 1
+	ChannelAllowNonStreamDisabled = 2
+)
+
+const (
+	ChannelAllowStreamEnabled  = 1
+	ChannelAllowStreamDisabled = 2
+)
+
+const (
 	ChannelTypeUnknown   = 0
 	ChannelTypeOpenAI    = 1
 	ChannelTypeAPI2D     = 2

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -64,7 +64,7 @@ func testChannel(channel *model.Channel, request ChatRequest) (error, *OpenAIErr
 
 	isStream := strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream")
 
-	if channel.AllowStreaming && isStream {
+	if channel.AllowStreaming == common.ChannelAllowStreamEnabled && isStream {
 		responseText := ""
 		scanner := bufio.NewScanner(resp.Body)
 		scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
@@ -145,7 +145,7 @@ func TestChannel(c *gin.Context) {
 		})
 		return
 	}
-	testRequest := buildTestRequest(channel.AllowStreaming)
+	testRequest := buildTestRequest(channel.AllowStreaming == common.ChannelAllowStreamEnabled)
 	tik := time.Now()
 	err, _ = testChannel(channel, *testRequest)
 	tok := time.Now()
@@ -210,7 +210,7 @@ func testAllChannels(notify bool) error {
 				continue
 			}
 			tik := time.Now()
-			testRequest := buildTestRequest(channel.AllowStreaming)
+			testRequest := buildTestRequest(channel.AllowStreaming == common.ChannelAllowStreamEnabled)
 			err, openaiErr := testChannel(channel, *testRequest)
 			tok := time.Now()
 			milliseconds := tok.Sub(tik).Milliseconds()

--- a/controller/channel.go
+++ b/controller/channel.go
@@ -1,12 +1,13 @@
 package controller
 
 import (
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"one-api/common"
 	"one-api/model"
 	"strconv"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 func GetAllChannels(c *gin.Context) {

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -46,6 +46,7 @@ type ChatRequest struct {
 	Model     string    `json:"model"`
 	Messages  []Message `json:"messages"`
 	MaxTokens int       `json:"max_tokens"`
+	Stream    bool      `json:"stream"`
 }
 
 type TextRequest struct {

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -12,7 +12,8 @@ import (
 )
 
 type ModelRequest struct {
-	Model string `json:"model"`
+	Model  string `json:"model"`
+	Stream bool   `json:"stream" default:"true"`
 }
 
 func Distribute() func(c *gin.Context) {
@@ -84,7 +85,7 @@ func Distribute() func(c *gin.Context) {
 					modelRequest.Model = "dall-e"
 				}
 			}
-			channel, err = model.CacheGetRandomSatisfiedChannel(userGroup, modelRequest.Model)
+			channel, err = model.CacheGetRandomSatisfiedChannel(userGroup, modelRequest.Model, modelRequest.Stream)
 			if err != nil {
 				message := fmt.Sprintf("当前分组 %s 下对于模型 %s 无可用渠道", userGroup, modelRequest.Model)
 				if channel != nil {

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"one-api/common"
 	"one-api/model"
@@ -85,6 +86,7 @@ func Distribute() func(c *gin.Context) {
 					modelRequest.Model = "dall-e"
 				}
 			}
+			log.Print(modelRequest.Stream)
 			channel, err = model.CacheGetRandomSatisfiedChannel(userGroup, modelRequest.Model, modelRequest.Stream)
 			if err != nil {
 				message := fmt.Sprintf("当前分组 %s 下对于模型 %s 无可用渠道", userGroup, modelRequest.Model)

--- a/model/ability.go
+++ b/model/ability.go
@@ -7,10 +7,12 @@ import (
 )
 
 type Ability struct {
-	Group     string `json:"group" gorm:"type:varchar(32);primaryKey;autoIncrement:false"`
-	Model     string `json:"model" gorm:"primaryKey;autoIncrement:false"`
-	ChannelId int    `json:"channel_id" gorm:"primaryKey;autoIncrement:false;index"`
-	Enabled   bool   `json:"enabled"`
+	Group             string `json:"group" gorm:"type:varchar(32);primaryKey;autoIncrement:false"`
+	Model             string `json:"model" gorm:"primaryKey;autoIncrement:false"`
+	ChannelId         int    `json:"channel_id" gorm:"primaryKey;autoIncrement:false;index"`
+	Enabled           bool   `json:"enabled"`
+	AllowStreaming    int    `json:"allow_streaming" gorm:"default:1"`
+	AllowNonStreaming int    `json:"allow_non_streaming" gorm:"default:1"`
 }
 
 func GetRandomSatisfiedChannel(group string, model string, stream bool) (*Channel, error) {
@@ -46,10 +48,12 @@ func (channel *Channel) AddAbilities() error {
 	for _, model := range models_ {
 		for _, group := range groups_ {
 			ability := Ability{
-				Group:     group,
-				Model:     model,
-				ChannelId: channel.Id,
-				Enabled:   channel.Status == common.ChannelStatusEnabled,
+				Group:             group,
+				Model:             model,
+				ChannelId:         channel.Id,
+				Enabled:           channel.Status == common.ChannelStatusEnabled,
+				AllowStreaming:    channel.AllowStreaming,
+				AllowNonStreaming: channel.AllowNonStreaming,
 			}
 			abilities = append(abilities, ability)
 		}

--- a/model/ability.go
+++ b/model/ability.go
@@ -12,13 +12,22 @@ type Ability struct {
 	Enabled   bool   `json:"enabled"`
 }
 
-func GetRandomSatisfiedChannel(group string, model string) (*Channel, error) {
+func GetRandomSatisfiedChannel(group string, model string, stream bool) (*Channel, error) {
 	ability := Ability{}
 	var err error = nil
-	if common.UsingSQLite {
-		err = DB.Where("`group` = ? and model = ? and enabled = 1", group, model).Order("RANDOM()").Limit(1).First(&ability).Error
+
+	cmd := "`group` = ? and model = ? and enabled = 1"
+
+	if stream {
+		cmd += " and allow_streaming = 1"
 	} else {
-		err = DB.Where("`group` = ? and model = ? and enabled = 1", group, model).Order("RAND()").Limit(1).First(&ability).Error
+		cmd += " and allow_non_streaming = 1"
+	}
+
+	if common.UsingSQLite {
+		err = DB.Where(cmd, group, model).Order("RANDOM()").Limit(1).First(&ability).Error
+	} else {
+		err = DB.Where(cmd, group, model).Order("RAND()").Limit(1).First(&ability).Error
 	}
 	if err != nil {
 		return nil, err

--- a/model/ability.go
+++ b/model/ability.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"one-api/common"
 	"strings"
 )
@@ -19,9 +20,9 @@ func GetRandomSatisfiedChannel(group string, model string, stream bool) (*Channe
 	cmd := "`group` = ? and model = ? and enabled = 1"
 
 	if stream {
-		cmd += " and allow_streaming = 1"
+		cmd += fmt.Sprintf(" and allow_streaming = %d", common.ChannelAllowStreamEnabled)
 	} else {
-		cmd += " and allow_non_streaming = 1"
+		cmd += fmt.Sprintf(" and allow_non_streaming = %d", common.ChannelAllowNonStreamEnabled)
 	}
 
 	if common.UsingSQLite {

--- a/model/cache.go
+++ b/model/cache.go
@@ -173,7 +173,7 @@ func CacheGetRandomSatisfiedChannel(group string, model string, stream bool) (*C
 
 	var filteredChannels []*Channel
 	for _, channel := range channels {
-		if (stream && channel.AllowStreaming) || (!stream && channel.AllowNonStreaming) {
+		if (stream && channel.AllowStreaming == common.ChannelAllowStreamEnabled) || (!stream && channel.AllowNonStreaming == common.ChannelAllowNonStreamEnabled) {
 			filteredChannels = append(filteredChannels, channel)
 		}
 	}

--- a/model/channel.go
+++ b/model/channel.go
@@ -24,8 +24,8 @@ type Channel struct {
 	Group              string  `json:"group" gorm:"type:varchar(32);default:'default'"`
 	UsedQuota          int64   `json:"used_quota" gorm:"bigint;default:0"`
 	ModelMapping       string  `json:"model_mapping" gorm:"type:varchar(1024);default:''"`
-	AllowStreaming     int     `json:"allow_streaming" gorm:"default:2"`
-	AllowNonStreaming  int     `json:"allow_non_streaming" gorm:"default:2"`
+	AllowStreaming     int     `json:"allow_streaming" gorm:"default:1"`
+	AllowNonStreaming  int     `json:"allow_non_streaming" gorm:"default:1"`
 }
 
 func GetAllChannels(startIdx int, num int, selectAll bool) ([]*Channel, error) {

--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -22,6 +22,8 @@ const EditChannel = () => {
     base_url: '',
     other: '',
     model_mapping: '',
+    allow_streaming: true,
+    allow_non_streaming: true,
     models: [],
     groups: ['default']
   };
@@ -94,6 +96,9 @@ const EditChannel = () => {
 
   useEffect(() => {
     let localModelOptions = [...originModelOptions];
+    if (!Array.isArray(inputs.models)) {
+      inputs.models = inputs.models.split(',');
+    }
     inputs.models.forEach((model) => {
       if (!localModelOptions.find((option) => option.key === model)) {
         localModelOptions.push({
@@ -125,6 +130,11 @@ const EditChannel = () => {
     }
     if (inputs.model_mapping !== '' && !verifyJSON(inputs.model_mapping)) {
       showInfo('模型映射必须是合法的 JSON 格式！');
+      return;
+    }
+    // allow streaming and allow non streaming cannot be both false
+    if (!inputs.allow_streaming && !inputs.allow_non_streaming) {
+      showInfo('流式请求和非流式请求不能同时禁用！');
       return;
     }
     let localInputs = inputs;
@@ -176,7 +186,7 @@ const EditChannel = () => {
                 <Message>
                   注意，<strong>模型部署名称必须和模型名称保持一致</strong>，因为 One API 会把请求体中的 model
                   参数替换为你的部署名称（模型名称中的点会被剔除），<a target='_blank'
-                                                                    href='https://github.com/songquanpeng/one-api/issues/133?notification_referrer_id=NT_kwDOAmJSYrM2NjIwMzI3NDgyOjM5OTk4MDUw#issuecomment-1571602271'>图片演示</a>。
+                    href='https://github.com/songquanpeng/one-api/issues/133?notification_referrer_id=NT_kwDOAmJSYrM2NjIwMzI3NDgyOjM5OTk4MDUw#issuecomment-1571602271'>图片演示</a>。
                 </Message>
                 <Form.Field>
                   <Form.Input
@@ -270,7 +280,7 @@ const EditChannel = () => {
             }}>清除所有模型</Button>
             <Input
               action={
-                <Button type={'button'} onClick={()=>{
+                <Button type={'button'} onClick={() => {
                   if (customModel.trim() === "") return;
                   if (inputs.models.includes(customModel)) return;
                   let localModels = [...inputs.models];
@@ -281,7 +291,7 @@ const EditChannel = () => {
                     text: customModel,
                     value: customModel,
                   });
-                  setModelOptions(modelOptions=>{
+                  setModelOptions(modelOptions => {
                     return [...modelOptions, ...localModelOptions];
                   });
                   setCustomModel('');
@@ -304,6 +314,26 @@ const EditChannel = () => {
               value={inputs.model_mapping}
               style={{ minHeight: 150, fontFamily: 'JetBrains Mono, Consolas' }}
               autoComplete='new-password'
+            />
+          </Form.Field>
+          <Form.Field>
+            <Form.Checkbox
+              checked={inputs.allow_streaming}
+              label='允许流式请求'
+              name='allow_streaming'
+              onChange={() => {
+                setInputs((inputs) => ({ ...inputs, allow_streaming: !inputs.allow_streaming }));
+              }}
+            />
+          </Form.Field>
+          <Form.Field>
+            <Form.Checkbox
+              checked={inputs.allow_non_streaming}
+              label='允许非流式请求'
+              name='allow_non_streaming'
+              onChange={() => {
+                setInputs((inputs) => ({ ...inputs, allow_non_streaming: !inputs.allow_non_streaming }));
+              }}
             />
           </Form.Field>
           {

--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -22,8 +22,8 @@ const EditChannel = () => {
     base_url: '',
     other: '',
     model_mapping: '',
-    allow_streaming: true,
-    allow_non_streaming: true,
+    allow_streaming: 1,
+    allow_non_streaming: 1,
     models: [],
     groups: ['default']
   };
@@ -133,7 +133,7 @@ const EditChannel = () => {
       return;
     }
     // allow streaming and allow non streaming cannot be both false
-    if (!inputs.allow_streaming && !inputs.allow_non_streaming) {
+    if (inputs.allow_streaming === 2 && inputs.allow_non_streaming === 2) {
       showInfo('流式请求和非流式请求不能同时禁用！');
       return;
     }
@@ -318,21 +318,21 @@ const EditChannel = () => {
           </Form.Field>
           <Form.Field>
             <Form.Checkbox
-              checked={inputs.allow_streaming}
+              checked={inputs.allow_streaming === 1}
               label='允许流式请求'
               name='allow_streaming'
               onChange={() => {
-                setInputs((inputs) => ({ ...inputs, allow_streaming: !inputs.allow_streaming }));
+                setInputs((inputs) => ({ ...inputs, allow_streaming: inputs.allow_streaming === 1 ? 2 : 1 }));
               }}
             />
           </Form.Field>
           <Form.Field>
             <Form.Checkbox
-              checked={inputs.allow_non_streaming}
+              checked={inputs.allow_non_streaming === 1}
               label='允许非流式请求'
               name='allow_non_streaming'
               onChange={() => {
-                setInputs((inputs) => ({ ...inputs, allow_non_streaming: !inputs.allow_non_streaming }));
+                setInputs((inputs) => ({ ...inputs, allow_non_streaming: inputs.allow_non_streaming === 1 ? 2 : 1 }));
               }}
             />
           </Form.Field>


### PR DESCRIPTION
我们可能有各种 OpenAI 源，但并非所有这些源都支持流式传输，或者有些源可能只允许流式传输，因此该选项可以让我们避免 JSON 错误和响应问题。