### PR TITLE
feat: add toggleable visibility for total quota using an eye icon

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -520,5 +520,6 @@
   "代理": "Proxy",
   "此项可选，用于通过代理站来进行 API 调用，请输入代理站地址，格式为：https://domain.com": "This is optional, used to make API calls through the proxy site, please enter the proxy site address, the format is: https://domain.com",
   "取消密码登录将导致所有未绑定其他登录方式的用户（包括管理员）无法通过密码登录，确认取消？": "Canceling password login will cause all users (including administrators) who have not bound other login methods to be unable to log in via password, confirm cancel?",
-  "按照如下格式输入：": "Enter in the following format:"
+  "按照如下格式输入：": "Enter in the following format:",
+  "点击查看": "click to view"
 }

--- a/web/src/components/LogsTable.js
+++ b/web/src/components/LogsTable.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Form, Header, Label, Pagination, Segment, Select, Table } from 'semantic-ui-react';
+import { Button, Form, Header, Label, Pagination, Segment, Select, Table, Icon } from 'semantic-ui-react';
 import { API, isAdmin, showError, timestamp2string } from '../helpers';
 
 import { ITEMS_PER_PAGE } from '../constants';
@@ -43,6 +43,7 @@ function renderType(type) {
 
 const LogsTable = () => {
   const [logs, setLogs] = useState([]);
+  const [showStat, setShowStat] = useState(false);
   const [loading, setLoading] = useState(true);
   const [activePage, setActivePage] = useState(1);
   const [searchKeyword, setSearchKeyword] = useState('');
@@ -92,6 +93,17 @@ const LogsTable = () => {
     }
   };
 
+  const handleEyeClick = async () => {
+    if (!showStat) {
+      if (isAdminUser) {
+        await getLogStat();
+      } else {
+        await getLogSelfStat();
+      }
+    }
+    setShowStat(!showStat);
+  };
+
   const loadLogs = async (startIdx) => {
     let url = '';
     let localStartTimestamp = Date.parse(start_timestamp) / 1000;
@@ -131,11 +143,6 @@ const LogsTable = () => {
     setLoading(true);
     setActivePage(1)
     await loadLogs(0);
-    if (isAdminUser) {
-      getLogStat().then();
-    } else {
-      getLogSelfStat().then();
-    }
   };
 
   useEffect(() => {
@@ -190,7 +197,17 @@ const LogsTable = () => {
   return (
     <>
       <Segment>
-        <Header as='h3'>使用明细（总消耗额度：{renderQuota(stat.quota)}）</Header>
+        <Header as='h3'>
+          使用明细（总消耗额度：
+          {showStat && renderQuota(stat.quota)}
+          <Icon 
+              name={showStat ? "eye slash" : "eye"} 
+              size="small" 
+              onClick={handleEyeClick} 
+              style={{ cursor: 'pointer', marginLeft: '5px', fontSize: '0.8em' }} 
+          />
+          ）
+        </Header>
         <Form>
           <Form.Group>
             {

--- a/web/src/components/LogsTable.js
+++ b/web/src/components/LogsTable.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Form, Header, Label, Pagination, Segment, Select, Table, Icon } from 'semantic-ui-react';
+import { Button, Form, Header, Label, Pagination, Segment, Select, Table } from 'semantic-ui-react';
 import { API, isAdmin, showError, timestamp2string } from '../helpers';
 
 import { ITEMS_PER_PAGE } from '../constants';
@@ -141,7 +141,7 @@ const LogsTable = () => {
 
   const refresh = async () => {
     setLoading(true);
-    setActivePage(1)
+    setActivePage(1);
     await loadLogs(0);
   };
 
@@ -176,7 +176,7 @@ const LogsTable = () => {
     if (logs.length === 0) return;
     setLoading(true);
     let sortedLogs = [...logs];
-    if (typeof sortedLogs[0][key] === 'string'){
+    if (typeof sortedLogs[0][key] === 'string') {
       sortedLogs.sort((a, b) => {
         return ('' + a[key]).localeCompare(b[key]);
       });
@@ -200,12 +200,7 @@ const LogsTable = () => {
         <Header as='h3'>
           使用明细（总消耗额度：
           {showStat && renderQuota(stat.quota)}
-          <Icon 
-              name={showStat ? "eye slash" : "eye"} 
-              size="small" 
-              onClick={handleEyeClick} 
-              style={{ cursor: 'pointer', marginLeft: '5px', fontSize: '0.8em' }} 
-          />
+          {!showStat && <span onClick={handleEyeClick} style={{ cursor: 'pointer', color: 'gray' }}>点击查看</span>}
           ）
         </Header>
         <Form>


### PR DESCRIPTION
![CleanShot 2023-08-19 at 15 50 17@2x](https://github.com/songquanpeng/one-api/assets/483419/85a8a2b8-320a-41d5-ac6c-4f560bc32c62)

这个页面载入和刷新都调用了总消耗额度求和，日志多了之后容易造成慢查询，尤其是用户端不停刷新的时候；

实际没有太多必要，改为默认隐藏，让用户主动点击去查询。

![CleanShot 2023-08-19 at 17 03 24@2x](https://github.com/songquanpeng/one-api/assets/483419/92f1aef0-69ea-48b9-b03d-9e472f51ef91)
![CleanShot 2023-08-19 at 17 03 30@2x](https://github.com/songquanpeng/one-api/assets/483419/36a6cc15-611f-4572-856b-d75668320b50)
