### PR TITLE
fix: missing url parameter for default chatLink

### DIFF
--- a/web/src/components/TokensTable.js
+++ b/web/src/components/TokensTable.js
@@ -138,7 +138,7 @@ const TokensTable = () => {
     let defaultUrl;
   
     if (chatLink) {
-      defaultUrl = chatLink + `/#/?settings={"key":"sk-${key}"}`;
+      defaultUrl = chatLink + `/#/?settings={"key":"sk-${key}","url":"${serverAddress}"}`;
     } else {
       defaultUrl = `https://chat.oneapi.pro/#/?settings={"key":"sk-${key}","url":"${serverAddress}"}`;
     }


### PR DESCRIPTION
在配置了服务器地址和聊天界面地址之后，令牌中直接点击聊天按钮时，携带的参数只有apikey，而没有url，要让请求生效的话，这两个参数必须同时传递。
![服务器地址](https://github.com/songquanpeng/one-api/assets/30925732/64529fea-99f7-47cb-a166-9f9ce0a5c6ef)
![聊天页面](https://github.com/songquanpeng/one-api/assets/30925732/3921b742-3762-42c6-ad7a-c2bd837aa0e7)

这是修改之前的：
![image](https://github.com/songquanpeng/one-api/assets/30925732/d6f5269f-65b4-408e-83f6-0ee2cf351870)

这是修改之后的：
![image](https://github.com/songquanpeng/one-api/assets/30925732/e922e34d-0151-4232-8fac-782debeca2d0)
