### PR TITLE
解决令牌页面聊天按钮丢失url参数的问题

### DIFF
--- a/web/src/components/TokensTable.js
+++ b/web/src/components/TokensTable.js
@@ -138,7 +138,7 @@ const TokensTable = () => {
     let defaultUrl;
   
     if (chatLink) {
-      defaultUrl = chatLink + `/#/?settings={"key":"sk-${key}"}`;
+      defaultUrl = chatLink + `/#/?settings={"key":"sk-${key}","url":"${serverAddress}"}`;
     } else {
       defaultUrl = `https://chat.oneapi.pro/#/?settings={"key":"sk-${key}","url":"${serverAddress}"}`;
     }


### PR DESCRIPTION
解决令牌页面聊天按钮丢失url参数的问题