### PR TITLE
feat: api can modify token's used and remains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as builder
+FROM node:18 as builder
 
 WORKDIR /build
 COPY web/package.json .
@@ -7,7 +7,7 @@ COPY ./web .
 COPY ./VERSION .
 RUN DISABLE_ESLINT_PLUGIN='true' REACT_APP_VERSION=$(cat VERSION) npm run build
 
-FROM golang AS builder2
+FROM golang:1.21.1 AS builder2
 
 ENV GO111MODULE=on \
     CGO_ENABLED=1 \

--- a/controller/token.go
+++ b/controller/token.go
@@ -1,11 +1,13 @@
 package controller
 
 import (
-	"github.com/gin-gonic/gin"
+	"fmt"
 	"net/http"
 	"one-api/common"
 	"one-api/model"
 	"strconv"
+
+	"github.com/gin-gonic/gin"
 )
 
 func GetAllTokens(c *gin.Context) {
@@ -159,42 +161,62 @@ func DeleteToken(c *gin.Context) {
 	return
 }
 
+type updateTokenDto struct {
+	Id             int     `json:"id"`
+	Status         int     `json:"status" gorm:"default:1"`
+	Name           *string `json:"name" gorm:"index" `
+	ExpiredTime    *int64  `json:"expired_time" gorm:"bigint;default:-1"` // -1 means never expired
+	RemainQuota    *int    `json:"remain_quota" gorm:"default:0"`
+	UnlimitedQuota *bool   `json:"unlimited_quota" gorm:"default:false"`
+	// AddRemainQuota add or subtract remain quota
+	AddRemainQuota int `json:"add_remain_quota"`
+	// AddUsedQuota add or subtract used quota
+	AddUsedQuota int `json:"add_used_quota"`
+}
+
 func UpdateToken(c *gin.Context) {
 	userId := c.GetInt("id")
 	statusOnly := c.Query("status_only")
-	token := model.Token{}
-	err := c.ShouldBindJSON(&token)
+	tokenPatch := new(updateTokenDto)
+	if err := c.ShouldBindJSON(tokenPatch); err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "parse request join: " + err.Error(),
+		})
+		return
+	}
+
+	if tokenPatch.Name != nil &&
+		(len(*tokenPatch.Name) > 30 || len(*tokenPatch.Name) == 0) {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "令牌名称错误，长度应在 1-30 之间",
+		})
+		return
+	}
+
+	cleanToken, err := model.GetTokenByIds(tokenPatch.Id, userId)
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
-			"message": err.Error(),
+			"message": fmt.Sprintf("get token by id %d: %s", tokenPatch.Id, err.Error()),
 		})
 		return
 	}
-	if len(token.Name) > 30 {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "令牌名称过长",
-		})
-		return
-	}
-	cleanToken, err := model.GetTokenByIds(token.Id, userId)
-	if err != nil {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": err.Error(),
-		})
-		return
-	}
-	if token.Status == common.TokenStatusEnabled {
-		if cleanToken.Status == common.TokenStatusExpired && cleanToken.ExpiredTime <= common.GetTimestamp() && cleanToken.ExpiredTime != -1 {
+
+	if tokenPatch.Status == common.TokenStatusEnabled {
+		if cleanToken.Status == common.TokenStatusExpired &&
+			cleanToken.ExpiredTime <= common.GetTimestamp() &&
+			cleanToken.ExpiredTime != -1 {
 			c.JSON(http.StatusOK, gin.H{
 				"success": false,
 				"message": "令牌已过期，无法启用，请先修改令牌过期时间，或者设置为永不过期",
 			})
 			return
 		}
-		if cleanToken.Status == common.TokenStatusExhausted && cleanToken.RemainQuota <= 0 && !cleanToken.UnlimitedQuota {
+		if cleanToken.Status == common.TokenStatusExhausted &&
+			cleanToken.RemainQuota <= 0 &&
+			!cleanToken.UnlimitedQuota {
 			c.JSON(http.StatusOK, gin.H{
 				"success": false,
 				"message": "令牌可用额度已用尽，无法启用，请先修改令牌剩余额度，或者设置为无限额度",
@@ -203,22 +225,34 @@ func UpdateToken(c *gin.Context) {
 		}
 	}
 	if statusOnly != "" {
-		cleanToken.Status = token.Status
+		cleanToken.Status = tokenPatch.Status
 	} else {
-		// If you add more fields, please also update token.Update()
-		cleanToken.Name = token.Name
-		cleanToken.ExpiredTime = token.ExpiredTime
-		cleanToken.RemainQuota = token.RemainQuota
-		cleanToken.UnlimitedQuota = token.UnlimitedQuota
+		// If you add more fields, please also update tokenPatch.Update()
+		if tokenPatch.Name != nil {
+			cleanToken.Name = *tokenPatch.Name
+		}
+		if tokenPatch.ExpiredTime != nil {
+			cleanToken.ExpiredTime = *tokenPatch.ExpiredTime
+		}
+		if tokenPatch.RemainQuota != nil {
+			cleanToken.RemainQuota = *tokenPatch.RemainQuota
+		}
+		if tokenPatch.UnlimitedQuota != nil {
+			cleanToken.UnlimitedQuota = *tokenPatch.UnlimitedQuota
+		}
 	}
-	err = cleanToken.Update()
-	if err != nil {
+
+	cleanToken.RemainQuota += tokenPatch.AddRemainQuota
+	cleanToken.UsedQuota += tokenPatch.AddUsedQuota
+
+	if err = cleanToken.Update(); err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
-			"message": err.Error(),
+			"message": "update token: " + err.Error(),
 		})
 		return
 	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",


### PR DESCRIPTION
修改：update token 接口支持对余额和已用 quota 数额进行动态修改。（现有接口行为不变）

理由：让 one-api 可以作为一个统一的计费系统，能够记录其他外部计费系统产生的费用，统一地管理令牌的余额和费用。毕竟 one-api 目前只支持 chat，而可能存在一些其他的基于 whisper、image 的用户服务，也会产生费用，并且希望能够统一管理和计费。

场景：给用户开通了 chat 和 image 服务，用户在两个系统都有开销，如果 one-api 不提供费用同步的接口，就会导致超花。比如用户可能在 image 服务已经把钱花完了，但是 one-api 这边计费没同步，用户还能继续 chat。

一些其他修改：

1. `node:16` 已经下不到了，改为 18
2. 给 `golang` 镜像指定版本