### PR TITLE
fix: change quota calc code (close #599)

### DIFF
--- a/controller/relay-text.go
+++ b/controller/relay-text.go
@@ -415,7 +415,6 @@ func relayTextHelper(c *gin.Context, relayMode int) *OpenAIErrorWithStatusCode {
 				completionRatio := common.GetCompletionRatio(textRequest.Model)
 				promptTokens = textResponse.Usage.PromptTokens
 				completionTokens = textResponse.Usage.CompletionTokens
-
 				quota = int(math.Ceil((float64(promptTokens) + float64(completionTokens)*completionRatio) * ratio))
 				if ratio != 0 && quota <= 0 {
 					quota = 1

--- a/controller/relay-text.go
+++ b/controller/relay-text.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"one-api/common"
 	"one-api/model"
@@ -415,8 +416,7 @@ func relayTextHelper(c *gin.Context, relayMode int) *OpenAIErrorWithStatusCode {
 				promptTokens = textResponse.Usage.PromptTokens
 				completionTokens = textResponse.Usage.CompletionTokens
 
-				quota = promptTokens + int(float64(completionTokens)*completionRatio)
-				quota = int(float64(quota) * ratio)
+				quota = int(math.Ceil((float64(promptTokens) + float64(completionTokens)*completionRatio) * ratio))
 				if ratio != 0 && quota <= 0 {
 					quota = 1
 				}


### PR DESCRIPTION
close #599
Use `float64` during calc and do `math.Ceil` after calc. 
This will result in the quota being used slightly more than the official standard, but it will be guaranteed that it will not be less.