### PR TITLE
增加模型权重配置，支持基于 TPM 权重的负载均衡

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -82,6 +82,7 @@ var QuotaRemindThreshold = 1000
 var PreConsumedQuota = 500
 var ApproximateTokenEnabled = false
 var RetryTimes = 0
+var DefaultWeight = 10
 
 var RootUserEmail = ""
 

--- a/common/utils.go
+++ b/common/utils.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"github.com/google/uuid"
 	"html/template"
 	"log"
 	"math/rand"
@@ -13,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func OpenBrowser(url string) {
@@ -206,4 +207,17 @@ func String2Int(str string) int {
 		return 0
 	}
 	return num
+}
+
+func SplitDistinct(s, sep string) []string {
+	splited := strings.Split(s, sep)
+	set := make(map[string]struct{})
+	list := []string{}
+	for _, item := range splited {
+		if _, ok := set[item]; !ok {
+			set[item] = struct{}{}
+			list = append(list, item)
+		}
+	}
+	return list
 }

--- a/controller/channel.go
+++ b/controller/channel.go
@@ -1,12 +1,13 @@
 package controller
 
 import (
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"one-api/common"
 	"one-api/model"
 	"strconv"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 func GetAllChannels(c *gin.Context) {
@@ -92,6 +93,7 @@ func AddChannel(c *gin.Context) {
 		}
 		localChannel := channel
 		localChannel.Key = key
+		localChannel.FixWeightMapping()
 		channels = append(channels, localChannel)
 	}
 	err = model.BatchInsertChannels(channels)
@@ -153,6 +155,9 @@ func UpdateChannel(c *gin.Context) {
 			"message": err.Error(),
 		})
 		return
+	}
+	if channel.Models != "" {
+		channel.FixWeightMapping()
 	}
 	err = channel.Update()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
+	github.com/mroth/weightedrand/v2 v2.1.0
 	github.com/pkoukk/tiktoken-go v0.1.5
 	golang.org/x/crypto v0.14.0
 	gorm.io/driver/mysql v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mroth/weightedrand/v2 v2.1.0 h1:o1ascnB1CIVzsqlfArQQjeMy1U0NcIbBO5rfd5E/OeU=
+github.com/mroth/weightedrand/v2 v2.1.0/go.mod h1:f2faGsfOGOwc1p94wzHKKZyTpcJUW7OJ/9U4yfiNAOU=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=

--- a/model/ability.go
+++ b/model/ability.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"one-api/common"
-	"strings"
 )
 
 type Ability struct {
@@ -40,8 +39,8 @@ func GetRandomSatisfiedChannel(group string, model string) (*Channel, error) {
 }
 
 func (channel *Channel) AddAbilities() error {
-	models_ := strings.Split(channel.Models, ",")
-	groups_ := strings.Split(channel.Group, ",")
+	models_ := channel.GetModels()
+	groups_ := channel.GetGroups()
 	abilities := make([]Ability, 0, len(models_))
 	for _, model := range models_ {
 		for _, group := range groups_ {

--- a/model/option.go
+++ b/model/option.go
@@ -71,6 +71,7 @@ func InitOptionMap() {
 	common.OptionMap["ChatLink"] = common.ChatLink
 	common.OptionMap["QuotaPerUnit"] = strconv.FormatFloat(common.QuotaPerUnit, 'f', -1, 64)
 	common.OptionMap["RetryTimes"] = strconv.Itoa(common.RetryTimes)
+	common.OptionMap["DefaultWeight"] = strconv.Itoa(common.DefaultWeight)
 	common.OptionMapRWMutex.Unlock()
 	loadOptionsFromDatabase()
 }
@@ -205,6 +206,8 @@ func updateOptionMap(key string, value string) (err error) {
 		common.PreConsumedQuota, _ = strconv.Atoi(value)
 	case "RetryTimes":
 		common.RetryTimes, _ = strconv.Atoi(value)
+	case "DefaultWeight":
+		common.DefaultWeight, _ = strconv.Atoi(value)
 	case "ModelRatio":
 		err = common.UpdateModelRatioByJSONString(value)
 	case "GroupRatio":

--- a/web/src/components/OperationSetting.js
+++ b/web/src/components/OperationSetting.js
@@ -21,7 +21,8 @@ const OperationSetting = () => {
     DisplayInCurrencyEnabled: '',
     DisplayTokenStatEnabled: '',
     ApproximateTokenEnabled: '',
-    RetryTimes: 0
+    RetryTimes: 0,
+    DefaultWeight: 10
   });
   const [originInputs, setOriginInputs] = useState({});
   let [loading, setLoading] = useState(false);
@@ -128,6 +129,9 @@ const OperationSetting = () => {
         if (originInputs['RetryTimes'] !== inputs.RetryTimes) {
           await updateOption('RetryTimes', inputs.RetryTimes);
         }
+        if (originInputs['DefaultWeight'] !== inputs.DefaultWeight) {
+          await updateOption('DefaultWeight', inputs.DefaultWeight);
+        }
         break;
     }
   };
@@ -150,7 +154,7 @@ const OperationSetting = () => {
           <Header as='h3'>
             通用设置
           </Header>
-          <Form.Group widths={4}>
+          <Form.Group widths={5}>
             <Form.Input
               label='充值链接'
               name='TopUpLink'
@@ -189,6 +193,17 @@ const OperationSetting = () => {
               autoComplete='new-password'
               value={inputs.RetryTimes}
               placeholder='失败重试次数'
+            />
+            <Form.Input
+              label='默认权重'
+              name='DefaultWeight'
+              type={'number'}
+              step='1'
+              min='0'
+              onChange={handleInputChange}
+              autoComplete='new-password'
+              value={inputs.DefaultWeight}
+              placeholder='默认权重'
             />
           </Form.Group>
           <Form.Group inline>

--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -10,6 +10,12 @@ const MODEL_MAPPING_EXAMPLE = {
   'gpt-4-32k-0314': 'gpt-4-32k'
 };
 
+const WEIGHT_MAPPING_EXAMPLE = {
+    'gpt-3.5-turbo-0301': 120,
+    'gpt-4-0314': 10,
+    'gpt-4-32k-0314': 10
+};
+
 function type2secretPrompt(type) {
   // inputs.type === 15 ? '按照如下格式输入：APIKey|SecretKey' : (inputs.type === 18 ? '按照如下格式输入：APPID|APISecret|APIKey' : '请输入渠道对应的鉴权密钥')
   switch (type) {
@@ -43,6 +49,7 @@ const EditChannel = () => {
     base_url: '',
     other: '',
     model_mapping: '',
+    weight_mapping: '',
     models: [],
     groups: ['default']
   };
@@ -104,6 +111,9 @@ const EditChannel = () => {
       }
       if (data.model_mapping !== '') {
         data.model_mapping = JSON.stringify(JSON.parse(data.model_mapping), null, 2);
+      }
+      if (data.weight_mapping !== '') {
+        data.weight_mapping = JSON.stringify(JSON.parse(data.weight_mapping), null, 2);
       }
       setInputs(data);
     } else {
@@ -177,6 +187,10 @@ const EditChannel = () => {
     if (inputs.model_mapping !== '' && !verifyJSON(inputs.model_mapping)) {
       showInfo('模型映射必须是合法的 JSON 格式！');
       return;
+    }
+    if (inputs.weight_mapping !== '' && !verifyJSON(inputs.weight_mapping)) {
+        showInfo('模型权重必须是合法的 JSON 格式！');
+        return;
     }
     let localInputs = inputs;
     if (localInputs.base_url && localInputs.base_url.endsWith('/')) {
@@ -392,6 +406,17 @@ const EditChannel = () => {
               name='model_mapping'
               onChange={handleInputChange}
               value={inputs.model_mapping}
+              style={{ minHeight: 150, fontFamily: 'JetBrains Mono, Consolas' }}
+              autoComplete='new-password'
+            />
+          </Form.Field>
+          <Form.Field>
+            <Form.TextArea
+              label='模型权重'
+              placeholder={`此项可选，用于修改请求体中的模型权重，为一个 JSON 字符串，键为请求中模型名称，值为要替换的模型权重，推荐填写模型的 TPM 值，例如：\n${JSON.stringify(WEIGHT_MAPPING_EXAMPLE, null, 2)}`}
+              name='weight_mapping'
+              onChange={handleInputChange}
+              value={inputs.weight_mapping}
               style={{ minHeight: 150, fontFamily: 'JetBrains Mono, Consolas' }}
               autoComplete='new-password'
             />


### PR DESCRIPTION
新增渠道时可指定模型权重映射，每个支持的模型都可以具有不同的权重，访问特定模型时，根据所有配置了该模型的渠道的权重列表随机筛选模型。
![image](https://github.com/songquanpeng/one-api/assets/15232241/a3d6180e-98af-4d7d-992e-54ccc7817a2c)

新增渠道时，可以不填该参数，后端根据 DefaultWeight 选项自动填充。
![image](https://github.com/songquanpeng/one-api/assets/15232241/f4bbde49-50fc-46b0-9f74-80b47616346e)

随后可以根据模型实际的 tpm 对权重进行修改。推荐以 Ktpm 单位来填写，即 tpm 为 120000 时填写 120，90000 时填写 90。
![image](https://github.com/songquanpeng/one-api/assets/15232241/04274c6e-b685-4f37-a724-eb52fc7aad3f)

默认权重可以在通用设置中修改。
![image](https://github.com/songquanpeng/one-api/assets/15232241/de05008a-b6a3-4004-bd98-b73bbc85d139)

对于 #281 中提到的几点问题：
1. 一般 tpm 更影响请求：
   从我司线上经验来看，tpm 确实更影响请求，我们一直采用基于 tpm 的负载均衡方案，此PR也已得到我司的生产实践验证。

2. 速率统计的依据是账号总的请求数，而不是模型分别的请求数
    对于 OpenAI 的模型来说，不同模型的 tpm 是独立计算的，即 gpt-3.5-turbo, gpt-3.5-turbo-16k, gpt-4 是独立的，但是 gpt-4-0314 与 gpt-4-0613 是否独立暂不确定，按 #281 的说法应该是不独立。

    对于 Azure OpenAI 的模型来说，tpm 取决于 deployment，gpt-35-turbo 与 gpt-4 都是独立部署的，因此 tpm 也是独立的。Azure OpenAI 可以分别部署 gpt-4-0314 和 gpt-4-0613，此时二者的 tpm 是独立的。

    因此 tpm 的统计维度取决于实际的部署情况，带后缀的模型的 tpm 有可能独立也可能不独立。

    此 PR 目前的统计维度是模型，不同的后缀是分开统计的，足以应对大多数情况。后续考虑添加配置策略，根据实际情况决定后缀版本模型的权重是独立计算还是非独立计算。

3. openai每分钟重置TPM统计的逻辑验证
    资源不够的情况下，频繁重试并不是很好的选择，而资源充足的情况下，目前已有的 retry 机制已经足够了。openai 返回的 rate limit 相关的 header 也许可以起到帮助。
    https://platform.openai.com/docs/guides/rate-limits/rate-limits-in-headers 

