### PR TITLE
fix: Numeric Sorting in Tables

### DIFF
--- a/web/src/components/ChannelsTable.js
+++ b/web/src/components/ChannelsTable.js
@@ -286,15 +286,15 @@ const ChannelsTable = () => {
     if (channels.length === 0) return;
     setLoading(true);
     let sortedChannels = [...channels];
-    if (typeof sortedChannels[0][key] === 'string') {
-      sortedChannels.sort((a, b) => {
-        return ('' + a[key]).localeCompare(b[key]);
-      });
-    } else {
-      sortedChannels.sort((a, b) => {
+    sortedChannels.sort((a, b) => {
+      if (!isNaN(a[key])) {
+        // If the value is numeric, subtract to sort
         return a[key] - b[key];
-      });
-    }
+      } else {
+        // If the value is not numeric, sort as strings
+        return ('' + a[key]).localeCompare(b[key]);
+      }
+    });
     if (sortedChannels[0].id === channels[0].id) {
       sortedChannels.reverse();
     }

--- a/web/src/components/ChannelsTable.js
+++ b/web/src/components/ChannelsTable.js
@@ -292,9 +292,7 @@ const ChannelsTable = () => {
       });
     } else {
       sortedChannels.sort((a, b) => {
-        if (a[key] === b[key]) return 0;
-        if (a[key] > b[key]) return -1;
-        if (a[key] < b[key]) return 1;
+        return a[key] - b[key];
       });
     }
     if (sortedChannels[0].id === channels[0].id) {
@@ -303,6 +301,7 @@ const ChannelsTable = () => {
     setChannels(sortedChannels);
     setLoading(false);
   };
+
 
   return (
     <>

--- a/web/src/components/RedemptionsTable.js
+++ b/web/src/components/RedemptionsTable.js
@@ -130,7 +130,13 @@ const RedemptionsTable = () => {
     setLoading(true);
     let sortedRedemptions = [...redemptions];
     sortedRedemptions.sort((a, b) => {
-      return ('' + a[key]).localeCompare(b[key]);
+      if (!isNaN(a[key])) {
+        // If the value is numeric, subtract to sort
+        return a[key] - b[key];
+      } else {
+        // If the value is not numeric, sort as strings
+        return ('' + a[key]).localeCompare(b[key]);
+      }
     });
     if (sortedRedemptions[0].id === redemptions[0].id) {
       sortedRedemptions.reverse();

--- a/web/src/components/TokensTable.js
+++ b/web/src/components/TokensTable.js
@@ -228,7 +228,13 @@ const TokensTable = () => {
     setLoading(true);
     let sortedTokens = [...tokens];
     sortedTokens.sort((a, b) => {
-      return ('' + a[key]).localeCompare(b[key]);
+      if (!isNaN(a[key])) {
+        // If the value is numeric, subtract to sort
+        return a[key] - b[key];
+      } else {
+        // If the value is not numeric, sort as strings
+        return ('' + a[key]).localeCompare(b[key]);
+      }
     });
     if (sortedTokens[0].id === tokens[0].id) {
       sortedTokens.reverse();

--- a/web/src/components/UsersTable.js
+++ b/web/src/components/UsersTable.js
@@ -133,7 +133,13 @@ const UsersTable = () => {
     setLoading(true);
     let sortedUsers = [...users];
     sortedUsers.sort((a, b) => {
-      return ('' + a[key]).localeCompare(b[key]);
+      if (!isNaN(a[key])) {
+        // If the value is numeric, subtract to sort
+        return a[key] - b[key];
+      } else {
+        // If the value is not numeric, sort as strings
+        return ('' + a[key]).localeCompare(b[key]);
+      }
     });
     if (sortedUsers[0].id === users[0].id) {
       sortedUsers.reverse();


### PR DESCRIPTION
There was an issue with the sorting function in the user table where **numeric values were being treated as strings**, leading to incorrect order. 

Specifically, "10" was being sorted next to "1", rather than after "9".
<img width="42" alt="Screenshot 2023-11-10 at 04 12 58" src="https://github.com/songquanpeng/one-api/assets/26314680/41b889a1-13b8-43a5-9f37-927aa5a948d3">

This PR ensures that both numeric and string values are sorted correctly in the user table. See below:

<img width="110" alt="Screenshot 2023-11-10 at 04 09 57" src="https://github.com/songquanpeng/one-api/assets/26314680/2cae832c-24ba-4732-bb3e-b6ae31cfe0f3">
