### PR TITLE
支持 Azure DALL-E 图像生成模型

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -154,11 +154,25 @@ type OpenAIEmbeddingResponse struct {
 	Usage  `json:"usage"`
 }
 
-type ImageResponse struct {
+type OpenAIImageResponse struct {
 	Created int `json:"created"`
 	Data    []struct {
 		Url string `json:"url"`
+	} `json:"data"`
+}
+
+type AzureDalle2ResultData struct {
+	Data []struct {
+		Url string `json:"url"`
 	}
+}
+
+type AzureDalle2Response struct {
+	Created int                   `json:"created"`
+	Expires int                   `json:"expires"`
+	ID      string                `json:"id"`
+	Result  AzureDalle2ResultData `json:"result"`
+	Status  string                `json:"status"`
 }
 
 type ChatCompletionsStreamResponseChoice struct {


### PR DESCRIPTION
close #581, close #692
1. Azure DALL-E 3 的部署名称强制改为 `dalle3` **除非进一步更改前台代码**以自定义（图像生成）部署名称。