### PR TITLE
fix: Skip JSON deserialization when accessing transcriptions and translations.

### DIFF
--- a/common/gin.go
+++ b/common/gin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"github.com/gin-gonic/gin"
 	"io"
+	"strings"
 )
 
 func UnmarshalBodyReusable(c *gin.Context, v any) error {
@@ -16,7 +17,13 @@ func UnmarshalBodyReusable(c *gin.Context, v any) error {
 	if err != nil {
 		return err
 	}
-	err = json.Unmarshal(requestBody, &v)
+	contentType := c.Request.Header.Get("Content-Type")
+	if strings.HasPrefix(contentType, "application/json") {
+		err = json.Unmarshal(requestBody, &v)
+	} else {
+		// skip for now
+		// TODO: someday non json request have variant model, we will need to implementation this
+	}
 	if err != nil {
 		return err
 	}

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -201,9 +201,9 @@ func Relay(c *gin.Context) {
 		relayMode = RelayModeEdits
 	} else if strings.HasPrefix(c.Request.URL.Path, "/v1/audio/speech") {
 		relayMode = RelayModeAudioSpeech
-	} else if strings.HasPrefix(c.Request.URL.Path, "/v1/audio/transcription") {
+	} else if strings.HasPrefix(c.Request.URL.Path, "/v1/audio/transcriptions") {
 		relayMode = RelayModeAudioTranscription
-	} else if strings.HasPrefix(c.Request.URL.Path, "/v1/audio/translation") {
+	} else if strings.HasPrefix(c.Request.URL.Path, "/v1/audio/translations") {
 		relayMode = RelayModeAudioTranslation
 	}
 	var err *OpenAIErrorWithStatusCode

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -40,7 +40,10 @@ func Distribute() func(c *gin.Context) {
 		} else {
 			// Select a channel for the user
 			var modelRequest ModelRequest
-			err := common.UnmarshalBodyReusable(c, &modelRequest)
+			var err error
+			if !strings.HasPrefix(c.Request.URL.Path, "/v1/audio/transcriptions") && !strings.HasPrefix(c.Request.URL.Path, "/v1/audio/translations") {
+				err = common.UnmarshalBodyReusable(c, &modelRequest)
+			}
 			if err != nil {
 				abortWithMessage(c, http.StatusBadRequest, "无效的请求")
 				return

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -40,10 +40,7 @@ func Distribute() func(c *gin.Context) {
 		} else {
 			// Select a channel for the user
 			var modelRequest ModelRequest
-			var err error
-			if !strings.HasPrefix(c.Request.URL.Path, "/v1/audio/transcriptions") && !strings.HasPrefix(c.Request.URL.Path, "/v1/audio/translations") {
-				err = common.UnmarshalBodyReusable(c, &modelRequest)
-			}
+			err := common.UnmarshalBodyReusable(c, &modelRequest)
 			if err != nil {
 				abortWithMessage(c, http.StatusBadRequest, "无效的请求")
 				return


### PR DESCRIPTION
close #719
只是临时修复，将之前移除的`if`加了回来，让这两个接口能用。  
彻底解决需要`common.UnmarshalBodyReusable`能同时支持`application/json`和`multipart/form-data`。  

已经在我的环境里测试通过。