### PR TITLE
增加部署映射，指定自定义Azure OpenAI的部署名称

### DIFF
--- a/controller/relay-text.go
+++ b/controller/relay-text.go
@@ -143,7 +143,8 @@ func relayTextHelper(c *gin.Context, relayMode int) *OpenAIErrorWithStatusCode {
 			} else {
 				deployment = model.ModelToDeployment(textRequest.Model)
 			}
-			fullRequestURL = fmt.Sprintf("%s/openai/deployments/%s/%s", baseURL, deployment, task)
+			requestURL = fmt.Sprintf("/openai/deployments/%s/%s", deployment, task)
+			fullRequestURL = getFullRequestURL(baseURL, requestURL, channelType)
 		}
 	case APITypeClaude:
 		fullRequestURL = "https://api.anthropic.com/v1/complete"

--- a/controller/relay-text.go
+++ b/controller/relay-text.go
@@ -141,15 +141,13 @@ func relayTextHelper(c *gin.Context, relayMode int) *OpenAIErrorWithStatusCode {
 			requestURL = fmt.Sprintf("%s?api-version=%s", requestURL, apiVersion)
 			baseURL = c.GetString("base_url")
 			task := strings.TrimPrefix(requestURL, "/v1/")
-			model_ := textRequest.Model
-			model_ = strings.Replace(model_, ".", "", -1)
-			// https://github.com/songquanpeng/one-api/issues/67
-			model_ = strings.TrimSuffix(model_, "-0301")
-			model_ = strings.TrimSuffix(model_, "-0314")
-			model_ = strings.TrimSuffix(model_, "-0613")
 
-			requestURL = fmt.Sprintf("/openai/deployments/%s/%s", model_, task)
-			fullRequestURL = getFullRequestURL(baseURL, requestURL, channelType)
+			deploymentMapping := c.GetStringMapString("deployment_mapping")
+			deployment := deploymentMapping[textRequest.Model]
+			if deployment == "" {
+				deployment = model.ModelToDeployment(textRequest.Model)
+			}
+			fullRequestURL = fmt.Sprintf("%s/openai/deployments/%s/%s", baseURL, deployment, task)
 		}
 	case APITypeClaude:
 		fullRequestURL = "https://api.anthropic.com/v1/complete"

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -85,7 +85,6 @@ func Distribute() func(c *gin.Context) {
 		switch channel.Type {
 		case common.ChannelTypeAzure:
 			c.Set("api_version", channel.Other)
-			c.Set("deployment_mapping", channel.GetDeploymentMapping())
 		case common.ChannelTypeXunfei:
 			c.Set("api_version", channel.Other)
 		case common.ChannelTypeAIProxyLibrary:

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -85,6 +85,7 @@ func Distribute() func(c *gin.Context) {
 		switch channel.Type {
 		case common.ChannelTypeAzure:
 			c.Set("api_version", channel.Other)
+			c.Set("deployment_mapping", channel.GetDeploymentMapping())
 		case common.ChannelTypeXunfei:
 			c.Set("api_version", channel.Other)
 		case common.ChannelTypeAIProxyLibrary:

--- a/model/channel.go
+++ b/model/channel.go
@@ -99,7 +99,7 @@ func (channel *Channel) GetBaseURL() string {
 }
 
 func (channel *Channel) GetModelMapping() (m map[string]string) {
-	if channel.ModelMapping == nil {
+	if channel.ModelMapping == nil || *channel.ModelMapping == "" {
 		return
 	}
 	err := json.Unmarshal([]byte(*channel.ModelMapping), &m)

--- a/web/src/components/ChannelsTable.js
+++ b/web/src/components/ChannelsTable.js
@@ -219,15 +219,15 @@ const ChannelsTable = () => {
     const res = await API.get(`/api/channel/test/${id}/`);
     const { success, message, time } = res.data;
     if (success) {
-      let newChannels = [...channels];
-      let realIdx = (activePage - 1) * ITEMS_PER_PAGE + idx;
-      newChannels[realIdx].response_time = time * 1000;
-      newChannels[realIdx].test_time = Date.now() / 1000;
-      setChannels(newChannels);
       showInfo(`通道 ${name} 测试成功，耗时 ${time.toFixed(2)} 秒。`);
     } else {
       showError(message);
     }
+    let newChannels = [...channels];
+    let realIdx = (activePage - 1) * ITEMS_PER_PAGE + idx;
+    newChannels[realIdx].response_time = time * 1000;
+    newChannels[realIdx].test_time = Date.now() / 1000;
+    setChannels(newChannels);
   };
 
   const testAllChannels = async () => {

--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -7,12 +7,8 @@ import { CHANNEL_OPTIONS } from '../../constants';
 const MODEL_MAPPING_EXAMPLE = {
   'gpt-3.5-turbo-0301': 'gpt-3.5-turbo',
   'gpt-4-0314': 'gpt-4',
-  'gpt-4-32k-0314': 'gpt-4-32k'
-};
-
-const DEPLOYMENT_MAPPING_EXAMPLE = {
-    'gpt-3.5-turbo': 'gpt-35-turbo',
-    'gpt-4': 'custom-gpt4'
+  'gpt-4-32k-0314': 'gpt-4-32k',
+  'gpt-4': 'azure-deployment-1',
 };
 
 function type2secretPrompt(type) {
@@ -394,7 +390,7 @@ const EditChannel = () => {
           <Form.Field>
             <Form.TextArea
               label='模型重定向'
-              placeholder={`此项可选，用于修改请求体中的模型名称，为一个 JSON 字符串，键为请求中模型名称，值为要替换的模型名称，例如：\n${JSON.stringify(MODEL_MAPPING_EXAMPLE, null, 2)}`}
+              placeholder={`此项可选，用于修改请求体中的模型名称，为一个 JSON 字符串，键为请求中模型名称，值为要替换的模型名称，如果是 Azure OpenAI 则替换为 deployment 名称，例如：\n${JSON.stringify(MODEL_MAPPING_EXAMPLE, null, 2)}`}
               name='model_mapping'
               onChange={handleInputChange}
               value={inputs.model_mapping}
@@ -402,23 +398,6 @@ const EditChannel = () => {
               autoComplete='new-password'
             />
           </Form.Field>
-          {
-            inputs.type === 3 && (
-              <>
-                <Form.Field>
-                    <Form.TextArea
-                    label='部署映射'
-                    placeholder={`此项可选，为一个 JSON 字符串，键为请求中模型名称，值为要替换的部署名称，用于修改 Azure OpenAI 的 deployment 参数。如果不填此参数，则部署名称必须与模型名称一致，例如 gpt-3.5-turbo 模型对应的部署名称应该为 gpt-35-turbo。若实际的部署名称不满足此规则，则可以通过该参数自定义。例如：\n${JSON.stringify(DEPLOYMENT_MAPPING_EXAMPLE, null, 2)}`}
-                    name='deployment_mapping'
-                    onChange={handleInputChange}
-                    value={inputs.deployment_mapping}
-                    style={{ minHeight: 150, fontFamily: 'JetBrains Mono, Consolas' }}
-                    autoComplete='new-password'
-                    />
-                </Form.Field>
-              </>
-            )
-          }
           {
             batch ? <Form.Field>
               <Form.TextArea

--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -10,6 +10,11 @@ const MODEL_MAPPING_EXAMPLE = {
   'gpt-4-32k-0314': 'gpt-4-32k'
 };
 
+const DEPLOYMENT_MAPPING_EXAMPLE = {
+    'gpt-3.5-turbo': 'gpt-35-turbo',
+    'gpt-4': 'custom-gpt4'
+};
+
 function type2secretPrompt(type) {
   // inputs.type === 15 ? '按照如下格式输入：APIKey|SecretKey' : (inputs.type === 18 ? '按照如下格式输入：APPID|APISecret|APIKey' : '请输入渠道对应的鉴权密钥')
   switch (type) {
@@ -43,6 +48,7 @@ const EditChannel = () => {
     base_url: '',
     other: '',
     model_mapping: '',
+    deployment_mapping: '',
     models: [],
     groups: ['default']
   };
@@ -396,6 +402,23 @@ const EditChannel = () => {
               autoComplete='new-password'
             />
           </Form.Field>
+          {
+            inputs.type === 3 && (
+              <>
+                <Form.Field>
+                    <Form.TextArea
+                    label='部署映射'
+                    placeholder={`此项可选，为一个 JSON 字符串，键为请求中模型名称，值为要替换的部署名称，用于修改 Azure OpenAI 的 deployment 参数。如果不填此参数，则部署名称必须与模型名称一致，例如 gpt-3.5-turbo 模型对应的部署名称应该为 gpt-35-turbo。若实际的部署名称不满足此规则，则可以通过该参数自定义。例如：\n${JSON.stringify(DEPLOYMENT_MAPPING_EXAMPLE, null, 2)}`}
+                    name='deployment_mapping'
+                    onChange={handleInputChange}
+                    value={inputs.deployment_mapping}
+                    style={{ minHeight: 150, fontFamily: 'JetBrains Mono, Consolas' }}
+                    autoComplete='new-password'
+                    />
+                </Form.Field>
+              </>
+            )
+          }
           {
             batch ? <Form.Field>
               <Form.TextArea


### PR DESCRIPTION
#133 中提到，Azure OpenAI 必须保证 deployment 与模型名称一致，这一限制不太灵活，例如有时候使用方没有办法修改部署名称，或者线上正在使用的不符合规则的部署名称不能直接修改。
![image](https://github.com/songquanpeng/one-api/assets/15232241/c1a4b5a1-a30b-46b2-a0f7-208b364726ac)

现增加 deployment_mapping，用于自定义模型与 deployment 的映射关系。
![image](https://github.com/songquanpeng/one-api/assets/15232241/bb310b09-0106-4433-bbba-a2e386540689)



