### PR TITLE
feat: 发送邮件时添加 Message-ID 

### DIFF
--- a/common/email.go
+++ b/common/email.go
@@ -14,10 +14,13 @@ func SendEmail(subject string, receiver string, content string) error {
 		SMTPFrom = SMTPAccount
 	}
 	encodedSubject := fmt.Sprintf("=?UTF-8?B?%s?=", base64.StdEncoding.EncodeToString([]byte(subject)))
-	
-	// Extract domain from SMTPFrom
-	domain := strings.Split(SMTPFrom, "@")[1]
 
+	// Extract domain from SMTPFrom
+	parts := strings.Split(SMTPFrom, "@")
+	var domain string
+	if len(parts) > 1 {
+		domain = parts[1]
+	}
 	// Generate a unique Message-ID
 	buf := make([]byte, 16)
 	_, err := rand.Read(buf)
@@ -29,7 +32,7 @@ func SendEmail(subject string, receiver string, content string) error {
 	mail := []byte(fmt.Sprintf("To: %s\r\n"+
 		"From: %s<%s>\r\n"+
 		"Subject: %s\r\n"+
-		"Message-ID: %s\r\n"+ // Add Message-ID to avoid being treated as spam, RFC 5322
+		"Message-ID: %s\r\n"+ // add Message-ID header to avoid being treated as spam, RFC 5322
 		"Content-Type: text/html; charset=UTF-8\r\n\r\n%s\r\n",
 		receiver, SystemName, SMTPFrom, encodedSubject, messageId, content))
 

--- a/common/email.go
+++ b/common/email.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"crypto/rand"
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
@@ -13,15 +14,29 @@ func SendEmail(subject string, receiver string, content string) error {
 		SMTPFrom = SMTPAccount
 	}
 	encodedSubject := fmt.Sprintf("=?UTF-8?B?%s?=", base64.StdEncoding.EncodeToString([]byte(subject)))
+	
+	// Extract domain from SMTPFrom
+	domain := strings.Split(SMTPFrom, "@")[1]
+
+	// Generate a unique Message-ID
+	buf := make([]byte, 16)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return err
+	}
+	messageId := fmt.Sprintf("<%x@%s>", buf, domain)
+
 	mail := []byte(fmt.Sprintf("To: %s\r\n"+
 		"From: %s<%s>\r\n"+
 		"Subject: %s\r\n"+
+		"Message-ID: %s\r\n"+ // Add Message-ID to avoid being treated as spam, RFC 5322
 		"Content-Type: text/html; charset=UTF-8\r\n\r\n%s\r\n",
-		receiver, SystemName, SMTPFrom, encodedSubject, content))
+		receiver, SystemName, SMTPFrom, encodedSubject, messageId, content))
+
 	auth := smtp.PlainAuth("", SMTPAccount, SMTPToken, SMTPServer)
 	addr := fmt.Sprintf("%s:%d", SMTPServer, SMTPPort)
 	to := strings.Split(receiver, ";")
-	var err error
+
 	if SMTPPort == 465 {
 		tlsConfig := &tls.Config{
 			InsecureSkipVerify: true,


### PR DESCRIPTION
## Pull Request - 添加 Message-ID 以修复 Gmail 拒收问题

### 错误描述

我们在发送电子邮件到 Gmail 时遇到了邮件拒收的问题。Gmail 服务器返回的错误信息如下：

> host gmail-smtp-in.l.google.com[] said: 550-5.7.1 [] Messages missing a valid Message-ID header are not accepted. Please visit https://support.google.com/mail/?p=RfcMessageNonCompliant and review RFC 5322 specifications for more information. 

这表明我们的邮件因为缺少有效的 `Message-ID` 标头而被 Gmail 拒绝接收。根据 RFC 5322 规范，`Message-ID` 是电子邮件标准协议的一部分，每封邮件都需要一个唯一的 `Message-ID`。

### 解决方案

为了解决这个问题，我在邮件发送功能中添加了生成和包含 `Message-ID` 的逻辑。`Message-ID` 是根据发件人的电子邮件地址动态生成的，确保了每封邮件都具有唯一的标识符。

修改后的代码主要在 `SendEmail` 函数中进行了以下更改：

1. 从 `SMTPFrom` 中提取域名部分。
2. 使用 `crypto/rand` 包生成一串随机字符。
3. 将这些字符和域名组合成一个唯一的 `Message-ID`。
4. 在邮件头信息中添加这个 `Message-ID`。

通过这些更改，我们的邮件现在包含了符合 RFC 5322 规范的有效 `Message-ID`，成功解决了 Gmail 拒收的问题。

---

请审阅这些更改，并考虑合并到主分支。如果有任何问题或需要进一步的讨论，请随时与我联系。