### PR TITLE
fix: Azure 渠道调用DALLE模型报错n_not_within_range

### DIFF
--- a/controller/relay-image.go
+++ b/controller/relay-image.go
@@ -79,7 +79,10 @@ func relayImageHelper(c *gin.Context, relayMode int) *OpenAIErrorWithStatusCode 
 
 	// Number of generated images validation
 	if isWithinRange(imageModel, imageRequest.N) == false {
-		return errorWrapper(errors.New("invalid value of n"), "n_not_within_range", http.StatusBadRequest)
+		// channel not azure
+		if channelType != common.ChannelTypeAzure {
+			return errorWrapper(errors.New("invalid value of n"), "n_not_within_range", http.StatusBadRequest)
+		}
 	}
 
 	// map model name
@@ -102,7 +105,7 @@ func relayImageHelper(c *gin.Context, relayMode int) *OpenAIErrorWithStatusCode 
 		baseURL = c.GetString("base_url")
 	}
 	fullRequestURL := getFullRequestURL(baseURL, requestURL, channelType)
-	if channelType == common.ChannelTypeAzure && relayMode == RelayModeImagesGenerations {
+	if channelType == common.ChannelTypeAzure {
 		// https://learn.microsoft.com/en-us/azure/ai-services/openai/dall-e-quickstart?tabs=dalle3%2Ccommand-line&pivots=rest-api
 		apiVersion := GetAPIVersion(c)
 		// https://{resource_name}.openai.azure.com/openai/deployments/dall-e-3/images/generations?api-version=2023-06-01-preview


### PR DESCRIPTION
- Add a condition to validate the n value only for non-Azure channels, ensuring it falls within the acceptable range.
- Fix Azure requestUrl compatibility

我已确认该 PR 已自测通过，相关截图如下：

<img width="1136" alt="image" src="https://github.com/songquanpeng/one-api/assets/3351486/c68e2a80-1ae4-4ddb-9050-5194c8cc409f">

