### PR TITLE
增加Cloudflare Workers Ai支持

### DIFF
--- a/Dockerfile-cn
+++ b/Dockerfile-cn
@@ -1,0 +1,35 @@
+FROM node:16 as builder
+
+WORKDIR /build
+COPY web/package.json .
+RUN npm config set registry https://registry.npm.taobao.org/ && npm install
+COPY ./web .
+COPY ./VERSION .
+RUN DISABLE_ESLINT_PLUGIN='true' REACT_APP_VERSION=$(cat VERSION) npm run build
+
+FROM golang AS builder2
+
+ENV GO111MODULE=on \
+    CGO_ENABLED=1 \
+    GOOS=linux \
+    GOPROXY=https://goproxy.cn
+
+WORKDIR /build
+ADD go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=builder /build/build ./web/build
+RUN go build -ldflags "-s -w -X 'one-api/common.Version=$(cat VERSION)' -extldflags '-static'" -o one-api
+
+FROM alpine
+
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories \
+    && apk update \
+    && apk upgrade \
+    && apk add --no-cache ca-certificates tzdata \
+    && update-ca-certificates 2>/dev/null || true
+
+COPY --from=builder2 /build/one-api /
+EXPOSE 3000
+WORKDIR /data
+ENTRYPOINT ["/one-api"]

--- a/common/constants.go
+++ b/common/constants.go
@@ -187,6 +187,7 @@ const (
 	ChannelTypeAIProxyLibrary = 21
 	ChannelTypeFastGPT        = 22
 	ChannelTypeTencent        = 23
+	ChannelTypeCloudflare     = 24
 )
 
 var ChannelBaseURLs = []string{
@@ -214,4 +215,5 @@ var ChannelBaseURLs = []string{
 	"https://api.aiproxy.io",            // 21
 	"https://fastgpt.run/api/openapi",   // 22
 	"https://hunyuan.cloud.tencent.com", //23
+	"https://api.cloudflare.com",        // 24
 }

--- a/common/model-ratio.go
+++ b/common/model-ratio.go
@@ -96,6 +96,9 @@ var ModelRatio = map[string]float64{
 	"embedding_s1_v1":           0.0715, // ¥0.001 / 1k tokens
 	"semantic_similarity_s1_v1": 0.0715, // ¥0.001 / 1k tokens
 	"hunyuan":                   7.143,  // ¥0.1 / 1k tokens  // https://cloud.tencent.com/document/product/1729/97731#e0e6be58-60c8-469f-bdeb-6c264ce3b4d0
+	"llama-2-7b-chat-fp16":      0.05,   // CF New Add Test Token
+	"llama-2-7b-chat-int8":      0.05,   // CF New Add Test Token
+	"mistral-7b-instruct-v0.1":  0.05,   // CF New Add Test Token
 }
 
 func ModelRatio2JSONString() string {

--- a/controller/model.go
+++ b/controller/model.go
@@ -540,6 +540,33 @@ func init() {
 			Root:       "hunyuan",
 			Parent:     nil,
 		},
+		{
+			Id:         "llama-2-7b-chat-fp16",
+			Object:     "model",
+			Created:    1677649963,
+			OwnedBy:    "cloudflare",
+			Permission: permission,
+			Root:       "cloudflare",
+			Parent:     nil,
+		},
+		{
+			Id:         "llama-2-7b-chat-int8",
+			Object:     "model",
+			Created:    1677649963,
+			OwnedBy:    "cloudflare",
+			Permission: permission,
+			Root:       "cloudflare",
+			Parent:     nil,
+		},
+		{
+			Id:         "mistral-7b-instruct-v0.1",
+			Object:     "model",
+			Created:    1677649963,
+			OwnedBy:    "cloudflare",
+			Permission: permission,
+			Root:       "cloudflare",
+			Parent:     nil,
+		},
 	}
 	openAIModelsMap = make(map[string]OpenAIModels)
 	for _, model := range openAIModels {

--- a/controller/relay-cloudflare.go
+++ b/controller/relay-cloudflare.go
@@ -1,0 +1,233 @@
+package controller
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"one-api/common"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+type CloudflareRequest struct {
+	Messages  []Message `json:"messages"`
+	Stream    bool      `json:"stream,omitempty"`
+	MaxTokens int       `json:"max_tokens"`
+	Prompt    any       `json:"prompt,omitempty"`
+}
+
+type CloudflareError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type CloudflareResult struct {
+	Response string `json:"response"`
+}
+type CloudflareResponse struct {
+	Result   CloudflareResult  `json:"result"`
+	Success  bool              `json:"success"`
+	Errors   []CloudflareError `json:"errors"`
+	Messages []string          `json:"messages"`
+}
+
+type CloudflareStreamResponse struct {
+	Reponse string `json:"response"`
+}
+
+func requestOpenAI2Cloudflare(textRequest GeneralOpenAIRequest) *CloudflareRequest {
+	cloudflareRequest := CloudflareRequest{
+		Messages:  textRequest.Messages,
+		Stream:    textRequest.Stream,
+		MaxTokens: -1,
+		Prompt:    textRequest.Prompt,
+	}
+	return &cloudflareRequest
+}
+
+func streamResponseCloudflare2OpenAI(cloudflareStreamResponse *CloudflareStreamResponse) *ChatCompletionsStreamResponse {
+	var choice ChatCompletionsStreamResponseChoice
+	choice.Delta.Content = cloudflareStreamResponse.Reponse
+	choice.FinishReason = &stopFinishReason
+	var response ChatCompletionsStreamResponse
+
+	response.Object = "chat.completion.chunk"
+	response.Model = "cloudflare"
+	response.Choices = []ChatCompletionsStreamResponseChoice{choice}
+
+	return &response
+}
+
+func responseCloudflare2OpenAI(cloudflareResponse *CloudflareResponse) *OpenAITextResponse {
+	choice := OpenAITextResponseChoice{
+		Index: 0,
+		Message: Message{
+			Role:    "assistant",
+			Content: strings.TrimPrefix(cloudflareResponse.Result.Response, " "),
+			Name:    nil,
+		},
+		FinishReason: stopFinishReason,
+	}
+	PromptTokens := 1
+	CompletionTokens := len(strings.TrimPrefix(cloudflareResponse.Result.Response, " "))
+	TotalTokens := CompletionTokens + PromptTokens
+	fullTextResponse := OpenAITextResponse{
+		Id:      fmt.Sprintf("chatcmpl-%s", common.GetUUID()),
+		Object:  "chat.completion",
+		Created: common.GetTimestamp(),
+		Choices: []OpenAITextResponseChoice{choice},
+		Usage: Usage{
+			PromptTokens:     PromptTokens,
+			TotalTokens:      TotalTokens,
+			CompletionTokens: CompletionTokens,
+		},
+	}
+	return &fullTextResponse
+}
+
+func cloudflareStreamHandler(c *gin.Context, resp *http.Response) (*OpenAIErrorWithStatusCode, string) {
+	responseText := ""
+	responseId := fmt.Sprintf("chatcmpl-%s", common.GetUUID())
+	createdTime := common.GetTimestamp()
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+		if i := strings.Index(string(data), "\n"); i >= 0 {
+			return i + 1, data[0:i], nil
+		}
+		if atEOF {
+			return len(data), data, nil
+		}
+		return 0, nil, nil
+	})
+	dataChan := make(chan string)
+	stopChan := make(chan bool)
+	go func() {
+		for scanner.Scan() {
+			data := scanner.Text()
+			if len(data) < 6 { // ignore blank line or wrong format
+				continue
+			}
+			if data[:6] != "data: " && data[:6] != "[DONE]" {
+				continue
+			}
+			dataChan <- data
+			data = data[6:]
+
+			if !strings.HasPrefix(data, "[DONE]") {
+				var streamResponse CloudflareStreamResponse
+				err := json.Unmarshal([]byte(data), &streamResponse)
+				if err != nil {
+					common.SysError("error unmarshalling stream response: " + err.Error())
+					continue // just ignore the error
+				}
+				responseText += streamResponse.Reponse
+			}
+		}
+		stopChan <- true
+	}()
+	setEventStreamHeaders(c)
+	c.Stream(func(w io.Writer) bool {
+		select {
+		case data := <-dataChan:
+			if strings.HasPrefix(data, "data: [DONE]") {
+				c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
+				return false
+			}
+			data = data[6:]
+			// some implementations may add \r at the end of data
+			data = strings.TrimSuffix(data, "\r")
+			var cloudflareStreamResponse CloudflareStreamResponse
+			err := json.Unmarshal([]byte(data), &cloudflareStreamResponse)
+			if err != nil {
+				common.SysError("error unmarshalling stream response: " + err.Error())
+				return true
+			}
+			responseText += cloudflareStreamResponse.Reponse
+			response := streamResponseCloudflare2OpenAI(&cloudflareStreamResponse)
+			response.Id = responseId
+			response.Created = createdTime
+			jsonStr, err := json.Marshal(response)
+			if err != nil {
+				common.SysError("error marshalling stream response: " + err.Error())
+				return true
+			}
+			c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+			return true
+		case <-stopChan:
+			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
+			return false
+		}
+	})
+	err := resp.Body.Close()
+	if err != nil {
+		return errorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), ""
+	}
+	return nil, responseText
+}
+
+func cloudflareHandler(c *gin.Context, resp *http.Response, promptTokens int, model string) (*OpenAIErrorWithStatusCode, *Usage) {
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errorWrapper(err, "read_response_body_failed", http.StatusInternalServerError), nil
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return errorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), nil
+	}
+	var cloudflareResponse CloudflareResponse
+	err = json.Unmarshal(responseBody, &cloudflareResponse)
+	if err != nil {
+		return errorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+	if len(cloudflareResponse.Errors) > 0 {
+		return &OpenAIErrorWithStatusCode{
+			OpenAIError: OpenAIError{
+				Message: cloudflareResponse.Errors[0].Message,
+				Type:    "",
+				Param:   "",
+				Code:    cloudflareResponse.Errors[0].Code,
+			},
+			StatusCode: resp.StatusCode,
+		}, nil
+	}
+	fullTextResponse := responseCloudflare2OpenAI(&cloudflareResponse)
+	// completionTokens := 0
+	completionTokens := countTokenText(cloudflareResponse.Result.Response, model)
+	usage := Usage{
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      promptTokens + completionTokens,
+	}
+	fullTextResponse.Usage = usage
+	jsonResponse, err := json.Marshal(fullTextResponse)
+	if err != nil {
+		return errorWrapper(err, "marshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(resp.StatusCode)
+	_, err = c.Writer.Write(jsonResponse)
+	return nil, &usage
+}
+
+func getCloudflareAccountID(apiKey string) (string, error) {
+	split := strings.Split(apiKey, "|")
+	if len(split) != 2 {
+		return "", errors.New("getCloudflareAccountID: Invalid API key format")
+	}
+	return split[0], nil
+}
+
+func getCloudflareAPI_Token(apiKey string) (string, error) {
+	split := strings.Split(apiKey, "|")
+	if len(split) != 2 {
+		return "", errors.New("getCloudflareAPI_Token: Invalid API key format")
+	}
+	return split[1], nil
+}

--- a/web/src/constants/channel.constants.js
+++ b/web/src/constants/channel.constants.js
@@ -21,5 +21,6 @@ export const CHANNEL_OPTIONS = [
   { key: 6, text: '代理：OpenAI Max', value: 6, color: 'violet' },
   { key: 9, text: '代理：AI.LS', value: 9, color: 'yellow' },
   { key: 12, text: '代理：API2GPT', value: 12, color: 'blue' },
-  { key: 13, text: '代理：AIGC2D', value: 13, color: 'purple' }
+  { key: 13, text: '代理：AIGC2D', value: 13, color: 'purple' },
+  { key: 24, text: 'Cloudflare Ai', value: 24, color: 'blue' }
 ];

--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -83,6 +83,9 @@ const EditChannel = () => {
         case 23:
           localModels = ['hunyuan'];
           break;
+        case 24:
+          localModels = ['llama-2-7b-chat-fp16','llama-2-7b-chat-int8','mistral-7b-instruct-v0.1'];
+          break;
       }
       setInputs((inputs) => ({ ...inputs, models: localModels }));
     }


### PR DESCRIPTION
- 增加Cloudflare Workers Ai渠道支持.
- 新增Workers Ai的文本生成类型接口,共三个模型：
    - `@cf/meta/llama-2-7b-chat-fp16`
    - `@cf/meta/llama-2-7b-chat-int8`
    - `@cf/mistral/mistral-7b-instruct-v0.1`
- 支持使用代理`Cloudflare AI Gateway`方式调用Workers Ai
- 实现Workers Ai的渠道测试功能
- 渠道密钥输入时,参考了项目中百度的实现,使用`用户ID|API_Token`形式输入.
- Token计费设置了0.05,因为Cloudflare Ai目前为免费形式提供

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/songquanpeng/one-api/assets/152241281/38f4e2a7-c2f9-4b69-98f2-21934977eb15)
![image](https://github.com/songquanpeng/one-api/assets/152241281/3fb0fc9a-3592-4a17-8ad6-92998406ce7d)
![image](https://github.com/songquanpeng/one-api/assets/152241281/cb220cc5-5591-4bc7-b436-39133d76e7a2)
