### PR TITLE
feat: Refactor response parsing logic to support multiple formats

### DIFF
--- a/controller/relay-audio.go
+++ b/controller/relay-audio.go
@@ -155,24 +155,24 @@ func relayAudioHelper(c *gin.Context, relayMode int) *OpenAIErrorWithStatusCode 
 		var openAIErr TextResponse
 		if err = json.Unmarshal(responseBody, &openAIErr); err == nil {
 			if openAIErr.Error.Message != "" {
-				return errorWrapper(errors.New(fmt.Sprintf("type %s, code %v, message %s", openAIErr.Error.Type, openAIErr.Error.Code, openAIErr.Error.Message)), "request_error", http.StatusInternalServerError)
+				return errorWrapper(fmt.Errorf("type %s, code %v, message %s", openAIErr.Error.Type, openAIErr.Error.Code, openAIErr.Error.Message), "request_error", http.StatusInternalServerError)
 			}
 		}
 
 		var text string
 		switch responseFormat {
 		case "json":
-			text, err = getTextFromJson(responseBody)
+			text, err = getTextFromJSON(responseBody)
 		case "text":
 			text, err = getTextFromText(responseBody)
 		case "srt":
-			text, err = getTextFromSrt(responseBody)
+			text, err = getTextFromSRT(responseBody)
 		case "verbose_json":
-			text, err = getTextFromVerboseJson(responseBody)
+			text, err = getTextFromVerboseJSON(responseBody)
 		case "vtt":
-			text, err = getTextFromVtt(responseBody)
+			text, err = getTextFromVTT(responseBody)
 		default:
-			return errorWrapper(errors.New("not_support_response_format"), "not_support_response_format", http.StatusInternalServerError)
+			return errorWrapper(errors.New("unexpected_response_format"), "unexpected_response_format", http.StatusInternalServerError)
 		}
 		if err != nil {
 			return errorWrapper(err, "get_text_from_body_err", http.StatusInternalServerError)
@@ -216,19 +216,19 @@ func relayAudioHelper(c *gin.Context, relayMode int) *OpenAIErrorWithStatusCode 
 	return nil
 }
 
-func getTextFromVtt(body []byte) (string, error) {
-	return getTextFromSrt(body)
+func getTextFromVTT(body []byte) (string, error) {
+	return getTextFromSRT(body)
 }
 
-func getTextFromVerboseJson(body []byte) (string, error) {
-	var whisperResponse WhisperVerboseJsonResponse
+func getTextFromVerboseJSON(body []byte) (string, error) {
+	var whisperResponse WhisperVerboseJSONResponse
 	if err := json.Unmarshal(body, &whisperResponse); err != nil {
 		return "", fmt.Errorf("unmarshal_response_body_failed err :%w", err)
 	}
 	return whisperResponse.Text, nil
 }
 
-func getTextFromSrt(body []byte) (string, error) {
+func getTextFromSRT(body []byte) (string, error) {
 	scanner := bufio.NewScanner(strings.NewReader(string(body)))
 	var builder strings.Builder
 	var textLine bool
@@ -253,8 +253,8 @@ func getTextFromText(body []byte) (string, error) {
 	return strings.TrimSuffix(string(body), "\n"), nil
 }
 
-func getTextFromJson(body []byte) (string, error) {
-	var whisperResponse WhisperJsonResponse
+func getTextFromJSON(body []byte) (string, error) {
+	var whisperResponse WhisperJSONResponse
 	if err := json.Unmarshal(body, &whisperResponse); err != nil {
 		return "", fmt.Errorf("unmarshal_response_body_failed err :%w", err)
 	}

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -141,8 +141,29 @@ type ImageRequest struct {
 	User           string `json:"user,omitempty"`
 }
 
-type WhisperResponse struct {
+type WhisperJsonResponse struct {
 	Text string `json:"text,omitempty"`
+}
+
+type WhisperVerboseJsonResponse struct {
+	Task     string    `json:"task"`
+	Language string    `json:"language"`
+	Duration float64   `json:"duration"`
+	Text     string    `json:"text"`
+	Segments []Segment `json:"segments"`
+}
+
+type Segment struct {
+	Id               int     `json:"id"`
+	Seek             int     `json:"seek"`
+	Start            float64 `json:"start"`
+	End              float64 `json:"end"`
+	Text             string  `json:"text"`
+	Tokens           []int   `json:"tokens"`
+	Temperature      float64 `json:"temperature"`
+	AvgLogprob       float64 `json:"avg_logprob"`
+	CompressionRatio float64 `json:"compression_ratio"`
+	NoSpeechProb     float64 `json:"no_speech_prob"`
 }
 
 type TextToSpeechRequest struct {

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -141,16 +141,16 @@ type ImageRequest struct {
 	User           string `json:"user,omitempty"`
 }
 
-type WhisperJsonResponse struct {
+type WhisperJSONResponse struct {
 	Text string `json:"text,omitempty"`
 }
 
-type WhisperVerboseJsonResponse struct {
-	Task     string    `json:"task"`
-	Language string    `json:"language"`
-	Duration float64   `json:"duration"`
-	Text     string    `json:"text"`
-	Segments []Segment `json:"segments"`
+type WhisperVerboseJSONResponse struct {
+	Task     string    `json:"task,omitempty"`
+	Language string    `json:"language,omitempty"`
+	Duration float64   `json:"duration,omitempty"`
+	Text     string    `json:"text,omitempty"`
+	Segments []Segment `json:"segments,omitempty"`
 }
 
 type Segment struct {


### PR DESCRIPTION
The parsing logic for responses in relay.go and relay-audio.go was refactored to support multiple response formats - 'json', 'text', 'srt', 'verbose_json', and 'vtt'. The existing `WhisperResponse` struct was renamed to `WhisperJsonResponse` and a new struct `WhisperVerboseJsonResponse` was added to support the 'verbose_json' format. Additional parsing functions were added to extract text from these new response types. This change was necessary to make the parsing logic more flexible and extendable for different types of responses.

close #735 

我已确认该 PR 已自测通过，相关截图如下：
whisper 模型 支持多种format响应（ 'json', 'text', 'srt', 'verbose_json', and 'vtt'）
![image](https://github.com/songquanpeng/one-api/assets/34326532/4b0d48d7-612c-4c8c-b272-35bd85f809ff)
