### PR TITLE
feat: able to set sqlite busy_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ graph LR
     + `TIKTOKEN_CACHE_DIR`：默认程序启动时会联网下载一些通用的词元的编码，如：`gpt-3.5-turbo`，在一些网络环境不稳定，或者离线情况，可能会导致启动有问题，可以配置此目录缓存数据，可迁移到离线环境。
     + `DATA_GYM_CACHE_DIR`：目前该配置作用与 `TIKTOKEN_CACHE_DIR` 一致，但是优先级没有它高。
 15. `RELAY_TIMEOUT`：中继超时设置，单位为秒，默认不设置超时时间。
+16. `SQLITE_BUSY_TIMEOUT`：SQLite 锁等待超时设置，单位为毫秒，默认 `3000`。
 
 ### 命令行参数
 1. `--port <port_number>`: 指定服务器监听的端口号，默认为 `3000`。

--- a/common/database.go
+++ b/common/database.go
@@ -3,4 +3,4 @@ package common
 var UsingSQLite = false
 var UsingPostgreSQL = false
 
-var SQLitePath = "one-api.db"
+var SQLitePath = "one-api.db?_busy_timeout=3000"

--- a/common/database.go
+++ b/common/database.go
@@ -3,4 +3,5 @@ package common
 var UsingSQLite = false
 var UsingPostgreSQL = false
 
-var SQLitePath = "one-api.db?_busy_timeout=3000"
+var SQLitePath = "one-api.db"
+var SQLiteBusyTimeout = GetOrDefault("SQLITE_BUSY_TIMEOUT", 3000)

--- a/model/main.go
+++ b/model/main.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
@@ -59,7 +60,8 @@ func chooseDB() (*gorm.DB, error) {
 	// Use SQLite
 	common.SysLog("SQL_DSN not set, using SQLite as database")
 	common.UsingSQLite = true
-	return gorm.Open(sqlite.Open(common.SQLitePath), &gorm.Config{
+	config := fmt.Sprintf("?_busy_timeout=%d", common.SQLiteBusyTimeout)
+	return gorm.Open(sqlite.Open(common.SQLitePath+config), &gorm.Config{
 		PrepareStmt: true, // precompile SQL
 	})
 }


### PR DESCRIPTION
在使用sqlite时，高并发下，用户余额更新操作时出现了失败的情况，报database is lock错误，从而导致用户余额更新不一致，添加busy_timeout参数，设置为3000毫秒，当数据库被锁定时，任何操作都会等待最多3秒钟的时间以获取数据库锁。