### PR TITLE
feat: reset image num to 1 when not given

### DIFF
--- a/controller/relay-image.go
+++ b/controller/relay-image.go
@@ -19,6 +19,9 @@ func isWithinRange(element string, value int) bool {
 	if _, ok := common.DalleGenerationImageAmounts[element]; !ok {
 		return false
 	}
+	if element == "dall-e-3" && value == 0 {
+		value = 1
+	}
 
 	min := common.DalleGenerationImageAmounts[element][0]
 	max := common.DalleGenerationImageAmounts[element][1]

--- a/controller/relay-image.go
+++ b/controller/relay-image.go
@@ -19,10 +19,6 @@ func isWithinRange(element string, value int) bool {
 	if _, ok := common.DalleGenerationImageAmounts[element]; !ok {
 		return false
 	}
-	if element == "dall-e-3" && value == 0 {
-		value = 1
-	}
-
 	min := common.DalleGenerationImageAmounts[element][0]
 	max := common.DalleGenerationImageAmounts[element][1]
 
@@ -43,6 +39,10 @@ func relayImageHelper(c *gin.Context, relayMode int) *OpenAIErrorWithStatusCode 
 	err := common.UnmarshalBodyReusable(c, &imageRequest)
 	if err != nil {
 		return errorWrapper(err, "bind_request_body_failed", http.StatusBadRequest)
+	}
+
+	if imageRequest.N == 0 {
+		imageRequest.N = 1
 	}
 
 	// Size validation


### PR DESCRIPTION
close #811 
![be2c3906e189aff0870bd0f401d77e6](https://github.com/songquanpeng/one-api/assets/137054651/9c938c63-4a74-4b9f-b2e1-476056febbaa)
对于官方文档，当没有设置参数n时，会默认为1。有些应用的请求没有默认n=1，会导致报错
我已确认该 PR 已自测通过，相关截图如下：