### PR TITLE
fix: openai response should contains `model`

### DIFF
--- a/controller/relay-ali.go
+++ b/controller/relay-ali.go
@@ -303,6 +303,7 @@ func aliHandler(c *gin.Context, resp *http.Response) (*OpenAIErrorWithStatusCode
 		}, nil
 	}
 	fullTextResponse := responseAli2OpenAI(&aliResponse)
+	fullTextResponse.Model = "qwen"
 	jsonResponse, err := json.Marshal(fullTextResponse)
 	if err != nil {
 		return errorWrapper(err, "marshal_response_body_failed", http.StatusInternalServerError), nil

--- a/controller/relay-baidu.go
+++ b/controller/relay-baidu.go
@@ -255,6 +255,7 @@ func baiduHandler(c *gin.Context, resp *http.Response) (*OpenAIErrorWithStatusCo
 		}, nil
 	}
 	fullTextResponse := responseBaidu2OpenAI(&baiduResponse)
+	fullTextResponse.Model = "ernie-bot"
 	jsonResponse, err := json.Marshal(fullTextResponse)
 	if err != nil {
 		return errorWrapper(err, "marshal_response_body_failed", http.StatusInternalServerError), nil

--- a/controller/relay-claude.go
+++ b/controller/relay-claude.go
@@ -204,6 +204,7 @@ func claudeHandler(c *gin.Context, resp *http.Response, promptTokens int, model 
 		}, nil
 	}
 	fullTextResponse := responseClaude2OpenAI(&claudeResponse)
+	fullTextResponse.Model = model
 	completionTokens := countTokenText(claudeResponse.Completion, model)
 	usage := Usage{
 		PromptTokens:     promptTokens,

--- a/controller/relay-gemini.go
+++ b/controller/relay-gemini.go
@@ -287,6 +287,7 @@ func geminiChatHandler(c *gin.Context, resp *http.Response, promptTokens int, mo
 		}, nil
 	}
 	fullTextResponse := responseGeminiChat2OpenAI(&geminiResponse)
+	fullTextResponse.Model = model
 	completionTokens := countTokenText(geminiResponse.GetResponseText(), model)
 	usage := Usage{
 		PromptTokens:     promptTokens,

--- a/controller/relay-palm.go
+++ b/controller/relay-palm.go
@@ -187,6 +187,7 @@ func palmHandler(c *gin.Context, resp *http.Response, promptTokens int, model st
 		}, nil
 	}
 	fullTextResponse := responsePaLM2OpenAI(&palmResponse)
+	fullTextResponse.Model = model
 	completionTokens := countTokenText(palmResponse.Candidates[0].Content, model)
 	usage := Usage{
 		PromptTokens:     promptTokens,

--- a/controller/relay-tencent.go
+++ b/controller/relay-tencent.go
@@ -237,6 +237,7 @@ func tencentHandler(c *gin.Context, resp *http.Response) (*OpenAIErrorWithStatus
 		}, nil
 	}
 	fullTextResponse := responseTencent2OpenAI(&TencentResponse)
+	fullTextResponse.Model = "hunyuan"
 	jsonResponse, err := json.Marshal(fullTextResponse)
 	if err != nil {
 		return errorWrapper(err, "marshal_response_body_failed", http.StatusInternalServerError), nil

--- a/controller/relay-zhipu.go
+++ b/controller/relay-zhipu.go
@@ -290,6 +290,7 @@ func zhipuHandler(c *gin.Context, resp *http.Response) (*OpenAIErrorWithStatusCo
 		}, nil
 	}
 	fullTextResponse := responseZhipu2OpenAI(&zhipuResponse)
+	fullTextResponse.Model = "chatglm"
 	jsonResponse, err := json.Marshal(fullTextResponse)
 	if err != nil {
 		return errorWrapper(err, "marshal_response_body_failed", http.StatusInternalServerError), nil

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -206,6 +206,7 @@ type OpenAITextResponseChoice struct {
 
 type OpenAITextResponse struct {
 	Id      string                     `json:"id"`
+	Model   string                     `json:"model,omitempty"`
 	Object  string                     `json:"object"`
 	Created int64                      `json:"created"`
 	Choices []OpenAITextResponseChoice `json:"choices"`


### PR DESCRIPTION
## 背景

<https://github.com/zurawiki/gptcommit> 这样的工具可以使用 openai 为 git 生成 commit 信息，但是只支持 gpt。

我试图用 one-api 将 gpt 请求转发给 google gemini，但是 gptcommit 报错称 response 中找不到 model 字段。

根据[ OpenAI 官方文档](https://platform.openai.com/docs/api-reference/chat/create)，gpt chat completion 的返回结构应为：

```json
{
  "id": "chatcmpl-123",
  "object": "chat.completion",
  "created": 1677652288,
  "model": "gpt-3.5-turbo-0613",
  "system_fingerprint": "fp_44709d6fcb",
  "choices": [{
    "index": 0,
    "message": {
      "role": "assistant",
      "content": "\n\nHello there, how may I assist you today?",
    },
    "logprobs": null,
    "finish_reason": "stop"
  }],
  "usage": {
    "prompt_tokens": 9,
    "completion_tokens": 12,
    "total_tokens": 21
  }
}

```

one-api relay 的 `OpenAITextResponse` 结构中确实缺少了 `Model` 字段。

## 修复

所以本 PR 为这个结构体和 gemini、claude 都加上了 Model 的返回。

## 自测

自测 OK，one-api 和 gptcommit 在我的 fork 版上已经正常工作。