### PR TITLE
feat: 改进阿里模型 stream 模式 & 使其支持联网搜索能力

### DIFF
--- a/common/model-ratio.go
+++ b/common/model-ratio.go
@@ -115,6 +115,9 @@ func UpdateModelRatioByJSONString(jsonStr string) error {
 }
 
 func GetModelRatio(name string) float64 {
+	if strings.HasPrefix(name, "qwen-") && strings.HasSuffix(name, "-internet") {
+		name = strings.TrimSuffix(name, "-internet")
+	}
 	ratio, ok := ModelRatio[name]
 	if !ok {
 		SysError("model ratio not found: " + name)

--- a/controller/relay-ali.go
+++ b/controller/relay-ali.go
@@ -28,8 +28,6 @@ type AliParameters struct {
 	Seed         		uint64  `json:"seed,omitempty"`
 	EnableSearch 		bool    `json:"enable_search,omitempty"`
 	IncrementalOutput 	bool	`json:"incremental_output,omitempty"`
-	Stream			bool	`json:"stream,omitempty"`
-	
 }
 
 type AliChatRequest struct {
@@ -104,7 +102,6 @@ func requestOpenAI2Ali(request GeneralOpenAIRequest) *AliChatRequest {
 		//	//Seed:         0,
 			EnableSearch: true,
 			IncrementalOutput=true,
-			Stream=request.Stream,
 		},
 	}
 }

--- a/controller/relay-ali.go
+++ b/controller/relay-ali.go
@@ -23,11 +23,11 @@ type AliInput struct {
 }
 
 type AliParameters struct {
-	TopP         		float64 `json:"top_p,omitempty"`
-	TopK         		int     `json:"top_k,omitempty"`
-	Seed         		uint64  `json:"seed,omitempty"`
-	EnableSearch 		bool    `json:"enable_search,omitempty"`
-	IncrementalOutput 	bool	`json:"incremental_output,omitempty"`
+	TopP              float64 `json:"top_p,omitempty"`
+	TopK              int     `json:"top_k,omitempty"`
+	Seed              uint64  `json:"seed,omitempty"`
+	EnableSearch      bool    `json:"enable_search,omitempty"`
+	IncrementalOutput bool    `json:"incremental_output,omitempty"`
 }
 
 type AliChatRequest struct {
@@ -82,6 +82,8 @@ type AliChatResponse struct {
 	AliError
 }
 
+const AliEnableSearchModelSuffix = "-internet"
+
 func requestOpenAI2Ali(request GeneralOpenAIRequest) *AliChatRequest {
 	messages := make([]AliMessage, 0, len(request.Messages))
 	for i := 0; i < len(request.Messages); i++ {
@@ -91,17 +93,20 @@ func requestOpenAI2Ali(request GeneralOpenAIRequest) *AliChatRequest {
 			Role:    strings.ToLower(message.Role),
 		})
 	}
+	enableSearch := false
+	aliModel := request.Model
+	if strings.HasSuffix(aliModel, AliEnableSearchModelSuffix) {
+		enableSearch = true
+		aliModel = strings.TrimSuffix(aliModel, AliEnableSearchModelSuffix)
+	}
 	return &AliChatRequest{
-		Model: request.Model,
+		Model: aliModel,
 		Input: AliInput{
 			Messages: messages,
 		},
-		Parameters: AliParameters{  // ChatGPT's parameters are not compatible with Ali's
-		//	TopP: request.TopP,
-		//	TopK: 50,
-		//	//Seed:         0,
-			EnableSearch: true,
-			IncrementalOutput=true,
+		Parameters: AliParameters{
+			EnableSearch:      enableSearch,
+			IncrementalOutput: request.Stream,
 		},
 	}
 }

--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -70,6 +70,13 @@ const EditChannel = () => {
           break;
         case 17:
           localModels = ['qwen-turbo', 'qwen-plus', 'qwen-max', 'qwen-max-longcontext', 'text-embedding-v1'];
+          let withInternetVersion = [];
+          for (let i = 0; i < localModels.length; i++) {
+            if (localModels[i].startsWith('qwen-')) {
+              withInternetVersion.push(localModels[i] + '-internet');
+            }
+          }
+          localModels = [...localModels, ...withInternetVersion];
           break;
         case 16:
           localModels = ['chatglm_turbo', 'chatglm_pro', 'chatglm_std', 'chatglm_lite'];


### PR DESCRIPTION
通义千问支持stream的增量模式，不需要每次去掉上次的前缀；实测qwen-max联网模式效果不错，添加了联网模式。如果别的模型有问题可以改为单独给qwen-max开放

close #issue_number

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/songquanpeng/one-api/assets/44284163/630c8d03-a61f-4706-bf4a-e6947bd8a55e)
