### PR TITLE
fix: gpt-4 vision 传入 base64 字符串图片时解析错误

### DIFF
--- a/common/image/image_test.go
+++ b/common/image/image_test.go
@@ -152,3 +152,20 @@ func TestGetImageSize(t *testing.T) {
 		})
 	}
 }
+
+func TestGetImageSizeFromBase64(t *testing.T) {
+	for i, c := range cases {
+		t.Run("Decode:"+strconv.Itoa(i), func(t *testing.T) {
+			resp, err := http.Get(c.url)
+			assert.NoError(t, err)
+			defer resp.Body.Close()
+			data, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			encoded := base64.StdEncoding.EncodeToString(data)
+			width, height, err := img.GetImageSizeFromBase64(encoded)
+			assert.NoError(t, err)
+			assert.Equal(t, c.width, width)
+			assert.Equal(t, c.height, height)
+		})
+	}
+}


### PR DESCRIPTION
 gpt-4 vision 传入base64字符串时，没有将base64解码，导致图片解析失败。
<img width="518" alt="iShot_2023-12-22_14 28 17" src="https://github.com/songquanpeng/one-api/assets/42402987/a63a517c-ddd6-4a8c-9e92-aae860c70dbb">

将base64解码后，读取正常
<img width="623" alt="iShot_2023-12-22_14 38 21" src="https://github.com/songquanpeng/one-api/assets/42402987/be5dce3a-c532-416f-96e1-45fc3f0ba1d0">
