### PR TITLE
feat:增加 Username Password DisplayName 的最大长度限制

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -3,18 +3,19 @@ package model
 import (
 	"errors"
 	"fmt"
-	"gorm.io/gorm"
 	"one-api/common"
 	"strings"
+
+	"gorm.io/gorm"
 )
 
 // User if you add sensitive fields, don't forget to clean them in setupLogin function.
 // Otherwise, the sensitive information will be saved on local storage in plain text!
 type User struct {
 	Id               int    `json:"id"`
-	Username         string `json:"username" gorm:"unique;index" validate:"max=12"`
-	Password         string `json:"password" gorm:"not null;" validate:"min=8,max=20"`
-	DisplayName      string `json:"display_name" gorm:"index" validate:"max=20"`
+	Username         string `json:"username" gorm:"unique;index" validate:"max=255"`
+	Password         string `json:"password" gorm:"not null;" validate:"min=8,max=255"`
+	DisplayName      string `json:"display_name" gorm:"index" validate:"max=255"`
 	Role             int    `json:"role" gorm:"type:int;default:1"`   // admin, common
 	Status           int    `json:"status" gorm:"type:int;default:1"` // enabled, disabled
 	Email            string `json:"email" gorm:"index" validate:"max=50"`


### PR DESCRIPTION
在集成其他用户服务和 one-api 自带的用户服务中，遇到了很大的困扰，特别是 username 的长度限制问题。

我现在使用的一个用户服务，用户 ID 是 Uuid，比如`f29e522a-1dce-413d-9668-b038e9abd202`。用户注册之后，我使用root管理员 api，同步在 one-api 上创建一个用户，填入`f29e522a-1dce-413d-9668-b038e9abd202`报错，因为 one-api 的用户名长度限制在 12。

很多用户服务的用户 ID，名称远远大于 12，可能是 30-40 长度等。因此，将 one-api 用户名称、用户显示名称、密码长度，都放大一点，对与其他用户系统集成很有好处。

为什么要增大密码长度？因为创建用户时，我将 one-api 用户的密码也需要设置为`f29e522a-1dce-413d-9668-b038e9abd202`。我的系统 one-api 作为一个基础组件，用来管理额度等，并不直接对外提供服务。