### PR TITLE
修改AMA问天为BotGem(官方改名)

### DIFF
--- a/web/berry/src/views/Token/component/TableRow.js
+++ b/web/berry/src/views/Token/component/TableRow.js
@@ -31,7 +31,7 @@ const COPY_OPTIONS = [
     url: 'https://chat.oneapi.pro/#/?settings={"key":"sk-{key}","url":"{serverAddress}"}',
     encode: false
   },
-  { key: 'ama', text: 'AMA 问天', url: 'ama://set-api-key?server={serverAddress}&key=sk-{key}', encode: true },
+  { key: 'ama', text: 'BotGem', url: 'ama://set-api-key?server={serverAddress}&key=sk-{key}', encode: true },
   { key: 'opencat', text: 'OpenCat', url: 'opencat://team/join?domain={serverAddress}&token=sk-{key}', encode: true }
 ];
 

--- a/web/default/src/components/TokensTable.js
+++ b/web/default/src/components/TokensTable.js
@@ -8,12 +8,12 @@ import { renderQuota } from '../helpers/render';
 
 const COPY_OPTIONS = [
   { key: 'next', text: 'ChatGPT Next Web', value: 'next' },
-  { key: 'ama', text: 'AMA 问天', value: 'ama' },
+  { key: 'ama', text: 'BotGem', value: 'ama' },
   { key: 'opencat', text: 'OpenCat', value: 'opencat' },
 ];
 
 const OPEN_LINK_OPTIONS = [
-  { key: 'ama', text: 'AMA 问天', value: 'ama' },
+  { key: 'ama', text: 'BotGem', value: 'ama' },
   { key: 'opencat', text: 'OpenCat', value: 'opencat' },
 ];
 


### PR DESCRIPTION
暂无相关Issue.

相关问题为 AMA问天改名为了BotGem.
<img width="956" alt="image" src="https://github.com/songquanpeng/one-api/assets/82748932/40c8ed64-9b0d-4181-b1cb-480750dbe962">

原本[https://bytemyth.com/ama](https://bytemyth.com/ama)现在默认跳转指[https://botgem.com/](https://botgem.com/)。
并且经过测试safari依旧可以通过ama://正常跳转。 故不作修改。

我已确认该 PR 已自测通过，相关截图如下：
<img width="894" alt="image" src="https://github.com/songquanpeng/one-api/assets/82748932/672b88c2-fb2f-44e7-90eb-b6ff76c97477">
