### PR TITLE
feat(audio): count whisper-1 quota by audio duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 *.db-journal
 logs
 data
+node_modules

--- a/common/audio/audio.go
+++ b/common/audio/audio.go
@@ -1,0 +1,19 @@
+package audio
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strconv"
+)
+
+// GetAudioDuration returns the duration of an audio file in seconds.
+func GetAudioDuration(ctx context.Context, filename string) (float64, error) {
+	// ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 {{input}}
+	c := exec.CommandContext(ctx, "ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", filename)
+	output, err := c.Output()
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseFloat(string(bytes.TrimSpace(output)), 64)
+}

--- a/common/file.go
+++ b/common/file.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"io"
+	"os"
+)
+
+// SaveTmpFile saves data to a temporary file. The filename would be apppended with a random string.
+func SaveTmpFile(filename string, data io.Reader) (string, error) {
+	f, err := os.CreateTemp(os.TempDir(), filename)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, data)
+	if err != nil {
+		return "", err
+	}
+	return f.Name(), nil
+}

--- a/common/http.go
+++ b/common/http.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+)
+
+func CloneRequest(old *http.Request) *http.Request {
+	req := old.Clone(old.Context())
+	oldBody, err := io.ReadAll(old.Body)
+	if err != nil {
+		return nil
+	}
+	err = old.Body.Close()
+	if err != nil {
+		return nil
+	}
+	old.Body = io.NopCloser(bytes.NewBuffer(oldBody))
+	req.Body = io.NopCloser(bytes.NewBuffer(oldBody))
+	return req
+}

--- a/common/model-ratio.go
+++ b/common/model-ratio.go
@@ -61,7 +61,7 @@ var ModelRatio = map[string]float64{
 	"text-davinci-003":          10,
 	"text-davinci-edit-001":     10,
 	"code-davinci-edit-001":     10,
-	"whisper-1":                 15,  // $0.006 / minute -> $0.006 / 150 words -> $0.006 / 200 tokens -> $0.03 / 1k tokens
+	"whisper-1":                 1,   // $0.006 / minute -> $0.002 / 20 seconds -> $0.002 / 1K tokens
 	"tts-1":                     7.5, // $0.015 / 1K characters
 	"tts-1-1106":                7.5,
 	"tts-1-hd":                  15, // $0.030 / 1K characters
@@ -156,6 +156,9 @@ func GetCompletionRatio(name string) float64 {
 	}
 	if strings.HasPrefix(name, "claude-2") {
 		return 2.965517
+	}
+	if strings.HasPrefix(name, "whisper-1") {
+		return 0 // only count input audio duration
 	}
 	return 1
 }

--- a/relay/util/common.go
+++ b/relay/util/common.go
@@ -136,11 +136,13 @@ func GetFullRequestURL(baseURL string, requestURL string, channelType int) strin
 
 func PostConsumeQuota(ctx context.Context, tokenId int, quotaDelta int, totalQuota int, userId int, channelId int, modelRatio float64, groupRatio float64, modelName string, tokenName string) {
 	// quotaDelta is remaining quota to be consumed
-	err := model.PostConsumeTokenQuota(tokenId, quotaDelta)
-	if err != nil {
-		common.SysError("error consuming token remain quota: " + err.Error())
+	if quotaDelta != 0 {
+		err := model.PostConsumeTokenQuota(tokenId, quotaDelta)
+		if err != nil {
+			common.SysError("error consuming token remain quota: " + err.Error())
+		}
 	}
-	err = model.CacheUpdateUserQuota(userId)
+	err := model.CacheUpdateUserQuota(userId)
 	if err != nil {
 		common.SysError("error update user quota cache: " + err.Error())
 	}


### PR DESCRIPTION
`whisper-1` 模型的计费仅由输入的语音时长决定，one-api 当前的实现是按输出的文本计算的估计值。

![image](https://github.com/songquanpeng/one-api/assets/15232241/d59dd2a5-f35c-4427-be20-ff9208e15985)

本 PR 实现了基于输入语音时长的计费方案，依赖 `ffprobe` 读取音频文件的时长，支持 openai 允许的所有格式，包括 mp3, mp4, mpeg, mpga, m4a, wav, 和 webm。

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/songquanpeng/one-api/assets/15232241/e3e19347-192c-4d99-bb57-f6570defcc21)
