### PR TITLE
fix: fix primary chat button in berry theme

### DIFF
--- a/web/berry/src/views/Token/component/TableRow.js
+++ b/web/berry/src/views/Token/component/TableRow.js
@@ -192,7 +192,7 @@ export default function TokensTableRow({ item, manageToken, handleOpenModal, set
               id={`switch-${item.id}`}
               checked={statusSwitch === 1}
               onChange={handleStatus}
-              // disabled={statusSwitch !== 1 && statusSwitch !== 2}
+            // disabled={statusSwitch !== 1 && statusSwitch !== 2}
             />
           </Tooltip>
         </TableCell>
@@ -222,7 +222,7 @@ export default function TokensTableRow({ item, manageToken, handleOpenModal, set
               </Button>
             </ButtonGroup>
             <ButtonGroup size="small" aria-label="split button">
-              <Button color="primary">聊天</Button>
+              <Button color="primary" onClick={(e) => handleCopy(COPY_OPTIONS[0], 'link')}>聊天</Button>
               <Button size="small" onClick={(e) => handleOpenMenu(e, 'link')}>
                 <IconCaretDownFilled size={'16px'} />
               </Button>


### PR DESCRIPTION
[//]: # (请按照以下格式关联 issue)
[//]: # (请在提交 PR 前确认所提交的功能可用，附上截图即可，这将有助于项目维护者 review & merge 该 PR，谢谢)
[//]: # (项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解)
[//]: # (开发者交流群：910657413)
[//]: # (请在提交 PR 之前删除上面的注释)

令牌后面的 聊天 主按钮点击没反应，缺少 onClick 事件。

close #950

我已确认该 PR 已自测通过，相关截图如下：

自测已经修复。