### PR TITLE
update: sync "text-moderation-*" model prices and record zero quota log

### DIFF
--- a/common/model-ratio.go
+++ b/common/model-ratio.go
@@ -78,8 +78,8 @@ var ModelRatio = map[string]float64{
 	"text-embedding-3-small":    0.01,
 	"text-embedding-3-large":    0.065,
 	"text-search-ada-doc-001":   10,
-	"text-moderation-stable":    0.1,
-	"text-moderation-latest":    0.1,
+	"text-moderation-stable":    0,		 // free to use
+	"text-moderation-latest":    0,	     // free to use
 	"dall-e-2":                  8,      // $0.016 - $0.020 / image
 	"dall-e-3":                  20,     // $0.040 - $0.120 / image
 	"claude-instant-1":          0.815,  // $1.63 / 1M tokens

--- a/relay/controller/helper.go
+++ b/relay/controller/helper.go
@@ -113,11 +113,17 @@ func postConsumeQuota(ctx context.Context, usage *openai.Usage, meta *util.Relay
 	if err != nil {
 		logger.Error(ctx, "error update user quota cache: "+err.Error())
 	}
-	if quota != 0 {
+
+	// if model ratio is zero, quota can be zero too
+	// without setting custom ratios, only "text-moderation-*" from OpenAI is currently 0
+	if quota >= 0 {
 		logContent := fmt.Sprintf("模型倍率 %.2f，分组倍率 %.2f，补全倍率 %.2f", modelRatio, groupRatio, completionRatio)
 		model.RecordConsumeLog(ctx, meta.UserId, meta.ChannelId, promptTokens, completionTokens, textRequest.Model, meta.TokenName, quota, logContent)
 		model.UpdateUserUsedQuotaAndRequestCount(meta.UserId, quota)
 		model.UpdateChannelUsedQuota(meta.ChannelId, quota)
+	}
+	if quota < 0 {
+		logger.Error(ctx, fmt.Sprintf("quota consumed is %d, something is wrong", quota))
 	}
 }
 


### PR DESCRIPTION
- 同步文本审核模型的价格, 改为 0 倍率, 参考[此链接](https://help.openai.com/en/articles/4936833-are-the-moderation-endpoint-and-content-filter-free-to-use).
- quota 为 0 时仍然进行消费记录, 对应此 PR 的免费模型调用记录.

> [!NOTE]
> 由于开发环境限制, 未能自测此 PR, 十分抱歉, 请维护者辅助.