### PR TITLE
feat: update default API version for Azure OpenAI

### DIFF
--- a/relay/controller/image.go
+++ b/relay/controller/image.go
@@ -61,7 +61,7 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 	if meta.ChannelType == common.ChannelTypeAzure {
 		// https://learn.microsoft.com/en-us/azure/ai-services/openai/dall-e-quickstart?tabs=dalle3%2Ccommand-line&pivots=rest-api
 		apiVersion := util.GetAzureAPIVersion(c)
-		// https://{resource_name}.openai.azure.com/openai/deployments/dall-e-3/images/generations?api-version=2023-06-01-preview
+		// https://{resource_name}.openai.azure.com/openai/deployments/dall-e-3/images/generations?api-version=2024-03-01-preview
 		fullRequestURL = fmt.Sprintf("%s/openai/deployments/%s/images/generations?api-version=%s", meta.BaseURL, imageRequest.Model, apiVersion)
 	}
 

--- a/web/air/src/pages/Channel/EditChannel.js
+++ b/web/air/src/pages/Channel/EditChannel.js
@@ -230,7 +230,7 @@ const EditChannel = (props) => {
             localInputs.base_url = localInputs.base_url.slice(0, localInputs.base_url.length - 1);
         }
         if (localInputs.type === 3 && localInputs.other === '') {
-            localInputs.other = '2023-06-01-preview';
+            localInputs.other = '2024-03-01-preview';
         }
         if (localInputs.type === 18 && localInputs.other === '') {
             localInputs.other = 'v2.1';
@@ -348,7 +348,7 @@ const EditChannel = (props) => {
                                 <Input
                                     label='默认 API 版本'
                                     name='azure_other'
-                                    placeholder={'请输入默认 API 版本，例如：2023-06-01-preview，该配置可以被实际的请求查询参数所覆盖'}
+                                    placeholder={'请输入默认 API 版本，例如：2024-03-01-preview，该配置可以被实际的请求查询参数所覆盖'}
                                     onChange={value => {
                                         handleInputChange('other', value)
                                     }}

--- a/web/berry/README.md
+++ b/web/berry/README.md
@@ -49,7 +49,7 @@ const typeConfig = {
       base_url: "请填写AZURE_OPENAI_ENDPOINT",
 
       // 注意：通过判断 `other` 是否有值来判断是否需要显示 `other` 输入框， 默认是没有值的
-      other: "请输入默认API版本，例如：2023-06-01-preview",
+      other: "请输入默认API版本，例如：2024-03-01-preview",
     },
     modelGroup: "openai", // 模型组名称,这个值是给 填入渠道支持模型 按钮使用的。 填入渠道支持模型 按钮会根据这个值来获取模型组，如果填写默认是 openai
   },

--- a/web/berry/src/views/Channel/type/Config.js
+++ b/web/berry/src/views/Channel/type/Config.js
@@ -41,7 +41,7 @@ const typeConfig = {
     },
     prompt: {
       base_url: "请填写AZURE_OPENAI_ENDPOINT",
-      other: "请输入默认API版本，例如：2023-06-01-preview",
+      other: "请输入默认API版本，例如：2024-03-01-preview",
     },
   },
   11: {

--- a/web/default/src/pages/Channel/EditChannel.js
+++ b/web/default/src/pages/Channel/EditChannel.js
@@ -160,7 +160,7 @@ const EditChannel = () => {
       localInputs.base_url = localInputs.base_url.slice(0, localInputs.base_url.length - 1);
     }
     if (localInputs.type === 3 && localInputs.other === '') {
-      localInputs.other = '2023-06-01-preview';
+      localInputs.other = '2024-03-01-preview';
     }
     if (localInputs.type === 18 && localInputs.other === '') {
       localInputs.other = 'v2.1';
@@ -242,7 +242,7 @@ const EditChannel = () => {
                   <Form.Input
                     label='默认 API 版本'
                     name='other'
-                    placeholder={'请输入默认 API 版本，例如：2023-06-01-preview，该配置可以被实际的请求查询参数所覆盖'}
+                    placeholder={'请输入默认 API 版本，例如：2024-03-01-preview，该配置可以被实际的请求查询参数所覆盖'}
                     onChange={handleInputChange}
                     value={inputs.other}
                     autoComplete='new-password'


### PR DESCRIPTION
Current default API version `2023-06-01-preview` will be retired on 2 April 2024, replace it with the latest `2024-03-01-preview`.

![image](https://github.com/songquanpeng/one-api/assets/1948179/21a63237-3f70-4b97-a8d5-ba0ae4ad4c8b)