### PR TITLE
百度千帆平台上的第三方大模型调用

### DIFF
--- a/relay/channel/baidu/adaptor.go
+++ b/relay/channel/baidu/adaptor.go
@@ -36,6 +36,8 @@ func (a *Adaptor) GetRequestURL(meta *util.RelayMeta) (string, error) {
 		fullRequestURL = "https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/bloomz_7b1"
 	case "Embedding-V1":
 		fullRequestURL = "https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/embeddings/embedding-v1"
+	default:
+               fullRequestURL = "https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/" + meta.ActualModelName
 	}
 	var accessToken string
 	var err error


### PR DESCRIPTION
百度千帆平台上的第三方大模型调用

close #issue_number

我已确认该 PR 已自测通过，相关截图如下：
模型名称需要与百度千帆平台的调试连接末尾名称一致： 如“https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/yi_34b_chat” 中的 yi_34b_chat
![image](https://github.com/songquanpeng/one-api/assets/21970770/6428257e-24b0-4db0-a7f9-3457cf691a65)
通过langchain-openai 调用
![image](https://github.com/songquanpeng/one-api/assets/21970770/385e3ffe-8215-4820-982d-eb378d161213)
