### PR TITLE
Fix GetImageSizeFromUrl for image url without Content-Type

### DIFF
--- a/common/image/image.go
+++ b/common/image/image.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Regex to match data URL pattern
-var	dataURLPattern = regexp.MustCompile(`data:image/([^;]+);base64,(.*)`)
+var dataURLPattern = regexp.MustCompile(`data:image/([^;]+);base64,(.*)`)
 
 func IsImageUrl(url string) (bool, error) {
 	resp, err := http.Head(url)
@@ -30,10 +30,6 @@ func IsImageUrl(url string) (bool, error) {
 }
 
 func GetImageSizeFromUrl(url string) (width int, height int, err error) {
-	isImage, err := IsImageUrl(url)
-	if !isImage {
-		return
-	}
 	resp, err := http.Get(url)
 	if err != nil {
 		return


### PR DESCRIPTION
Not all images carry a `Content-Type` header such as `image/`. When utilizing object storage solutions like AWS S3, it is essential to define the `Content-Type` at the time of upload; failing to do so will result in the adoption of the default content type, `binary/octet-stream`.

At present, the benefit of identifying the `Content-Type` lies in conserving bandwidth by filtering out invalid image URLs. Nevertheless, this approach incurs the expense of an additional `HEAD` request for each URL. Considering that the majority of URLs point to valid images, the overhead introduced by these requests outweighs the potential benefits.