### PR TITLE
ZhiPuAI compatibility with the temperature topP parameter (0.0, 1)

### DIFF
--- a/relay/channel/zhipu/adaptor.go
+++ b/relay/channel/zhipu/adaptor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/songquanpeng/one-api/relay/model"
 	"github.com/songquanpeng/one-api/relay/util"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 )
@@ -52,9 +53,13 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 	if request == nil {
 		return nil, errors.New("request is nil")
 	}
-	if request.TopP >= 1 {
-		request.TopP = 0.99
-	}
+	// TopP (0.0, 1.0)
+	request.TopP = math.Min(0.99, request.TopP)
+	request.TopP = math.Max(0.01, request.TopP)
+
+	// Temperature (0.0, 1.0)
+	request.Temperature = math.Min(0.99, request.Temperature)
+	request.Temperature = math.Max(0.01, request.Temperature)
 	a.SetVersionByModeName(request.Model)
 	if a.APIVersion == "v4" {
 		return request, nil


### PR DESCRIPTION
Zhi Pu AI Channel's safer compatibility with the temperature topP parameter (0.0, 1)

**Before**
![image](https://github.com/songquanpeng/one-api/assets/10176784/4e8bddfd-c1a6-46a8-96ad-7ac1593a7e81)

**After**
我已确认该 PR 已自测通过，相关截图如下：
<img width="1401" alt="image" src="https://github.com/songquanpeng/one-api/assets/10176784/b67f825e-f411-4b6d-b884-cfbedb92eb1c">
