### PR TITLE
修复百度模型中URL的字符串判断bug；

### DIFF
--- a/relay/channel/baidu/adaptor.go
+++ b/relay/channel/baidu/adaptor.go
@@ -3,14 +3,15 @@ package baidu
 import (
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/songquanpeng/one-api/relay/channel"
 	"github.com/songquanpeng/one-api/relay/constant"
 	"github.com/songquanpeng/one-api/relay/model"
 	"github.com/songquanpeng/one-api/relay/util"
-	"io"
-	"net/http"
-	"strings"
 )
 
 type Adaptor struct {
@@ -23,7 +24,13 @@ func (a *Adaptor) Init(meta *util.RelayMeta) {
 func (a *Adaptor) GetRequestURL(meta *util.RelayMeta) (string, error) {
 	// https://cloud.baidu.com/doc/WENXINWORKSHOP/s/clntwmv7t
 	suffix := "chat/"
-	if strings.HasPrefix("Embedding", meta.ActualModelName) {
+	if strings.HasPrefix(meta.ActualModelName, "Embedding") {
+		suffix = "embeddings/"
+	}
+	if strings.HasPrefix(meta.ActualModelName, "bge-large") {
+		suffix = "embeddings/"
+	}
+	if strings.HasPrefix(meta.ActualModelName, "tao-8k") {
 		suffix = "embeddings/"
 	}
 	switch meta.ActualModelName {
@@ -45,6 +52,12 @@ func (a *Adaptor) GetRequestURL(meta *util.RelayMeta) (string, error) {
 		suffix += "bloomz_7b1"
 	case "Embedding-V1":
 		suffix += "embedding-v1"
+	case "bge-large-zh":
+		suffix += "bge_large_zh"
+	case "bge-large-en":
+		suffix += "bge_large_en"
+	case "tao-8k":
+		suffix += "tao_8k"
 	default:
 		suffix += meta.ActualModelName
 	}

--- a/relay/channel/baidu/constants.go
+++ b/relay/channel/baidu/constants.go
@@ -7,4 +7,7 @@ var ModelList = []string{
 	"ERNIE-Speed",
 	"ERNIE-Bot-turbo",
 	"Embedding-V1",
+	"bge-large-zh",
+	"bge-large-en",
+	"tao-8k",
 }


### PR DESCRIPTION
close #1144
修复百度模型中URL的字符串判断bug；
添加百度的另外3个向量模型【"bge-large-zh",
	"bge-large-en",
	"tao-8k",
】

[//]: # (请按照以下格式关联 issue)
[//]: # (请在提交 PR 前确认所提交的功能可用，附上截图即可，这将有助于项目维护者 review & merge 该 PR，谢谢)
[//]: # (项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解)
[//]: # (开发者交流群：910657413)
[//]: # (请在提交 PR 之前删除上面的注释)

close #issue_number

我已确认该 PR 已自测通过，相关截图如下：
<img width="802" alt="image" src="https://github.com/songquanpeng/one-api/assets/28046225/9376a1c6-3c64-47c7-896d-efe24f73aad1">
<img width="535" alt="image" src="https://github.com/songquanpeng/one-api/assets/28046225/84afdd0d-e672-4375-a3bc-5dd56bac6ce8">
<img width="606" alt="image" src="https://github.com/songquanpeng/one-api/assets/28046225/1aea346e-1c43-4780-bbf0-8680abd2d153">
<img width="1149" alt="image" src="https://github.com/songquanpeng/one-api/assets/28046225/6cdebb3e-7d90-490b-bcbd-84d58e7a159f">
