### PR TITLE
fix: 修复`berry`主题下`令牌`在`编辑`后点击`新建`弹窗值的初始化问题

### DIFF
--- a/web/berry/src/views/Setting/component/OtherSetting.js
+++ b/web/berry/src/views/Setting/component/OtherSetting.js
@@ -265,7 +265,7 @@ const OtherSetting = () => {
                   multiline
                   maxRows={15}
                   id="Footer"
-                  label="公告"
+                  label="页脚"
                   value={inputs.Footer}
                   name="Footer"
                   onChange={handleInputChange}

--- a/web/berry/src/views/Token/component/EditModal.js
+++ b/web/berry/src/views/Token/component/EditModal.js
@@ -87,6 +87,8 @@ const EditModal = ({ open, tokenId, onCancel, onOk }) => {
   useEffect(() => {
     if (tokenId) {
       loadToken().then();
+    } else {
+      setInputs({...originInputs});
     }
   }, [tokenId]);
 


### PR DESCRIPTION
### 问题描述

在`berry`主题中，存在一个问题，当用户在修改一个令牌后点击新建令牌时，新建令牌弹窗会错误地展示上一次编辑的值。

### 复现步骤

1. 导航至`令牌`管理页面。
2. 选择任意令牌进行`编辑`。
3. 在编辑界面，点击`取消`返回。
4. 点击`+新建令牌`按钮打开新建令牌弹窗。

### 预期结果

新建令牌弹窗应显示空白表单，等待用户输入新的令牌信息。

### 实际结果

新建令牌弹窗错误地展示了之前编辑的令牌信息。

我已确认该 PR 已自测通过，相关截图如下：
![old](https://github.com/songquanpeng/one-api/assets/46555117/e01ed03e-8adf-47fa-80ee-e18343b8c9e7)
![new](https://github.com/songquanpeng/one-api/assets/46555117/8ebc27e7-7623-4810-a1a9-01871b1a7f96)