### PR TITLE
fix: fix panel cards style(修复penal卡片高度不一致)

### DIFF
--- a/web/berry/src/views/Dashboard/component/StatisticalLineChartCard.js
+++ b/web/berry/src/views/Dashboard/component/StatisticalLineChartCard.js
@@ -65,7 +65,7 @@ const StatisticalLineChartCard = ({ isLoading, title, chartData, todayValue }) =
       ) : (
         <CardWrapper border={false} content={false}>
           <Box sx={{ p: 2.25 }}>
-            <Grid container direction="column">
+            <Grid>
               <Grid item sx={{ mb: 0.75 }}>
                 <Grid container alignItems="center">
                   <Grid item xs={6}>


### PR DESCRIPTION
我已确认该 PR 已自测通过，相关截图如下：
<img width="1518" alt="image" src="https://github.com/songquanpeng/one-api/assets/16076993/e982e292-5200-4a85-9941-877f51b6e3a6">


原始样式问题截图：
![telegram-cloud-photo-size-5-6316788537906806971-y](https://github.com/songquanpeng/one-api/assets/16076993/82da32f3-1091-4bc5-8865-c03ad548f28f)
