### PR TITLE
fix only extract and record the most critical part.

### DIFF
--- a/.github/workflows/docker-image-amd64.yml
+++ b/.github/workflows/docker-image-amd64.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image-amd64.yml
+++ b/.github/workflows/docker-image-amd64.yml
@@ -1,61 +1,45 @@
-name: Publish Docker image (amd64)
+name: Publish Docker Image
 
 on:
-  push:
-    tags:
-      - '*'
   workflow_dispatch:
-    inputs:
-      name:
-        description: 'reason'
-        required: false
+  release:
+    types: [published]
+
 jobs:
-  push_to_registries:
-    name: Push Docker image to multiple registries
+  push_to_registry:
+    name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
-
-      - name: Check repository URL
-        run: |
-          REPO_URL=$(git config --get remote.origin.url)
-          if [[ $REPO_URL == *"pro" ]]; then
-            exit 1
-          fi        
-
-      - name: Save version info
-        run: |
-          git describe --tags > VERSION 
-
+        uses: actions/checkout@v4
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          images: |
-            justsong/one-api
-            ghcr.io/${{ github.repository }}
+          images: yangclivia/one-api
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
 
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/relay/channel/openai/token.go
+++ b/relay/channel/openai/token.go
@@ -102,7 +102,8 @@ func CountTokenMessages(messages []model.Message, model string) int {
 						}
 						imageTokens, err := countImageTokens(url, detail)
 						if err != nil {
-							logger.SysError("error counting image tokens: " + err.Error())
+							//Due to the excessive length of the error information, only extract and record the most critical part.
+							logger.SysError(fmt.Sprintf("error counting image tokens. Error type: %T", err))
 						} else {
 							tokenNum += imageTokens
 						}


### PR DESCRIPTION
### Because sometimes when certain models transfer files, the error information here becomes too long, leading to very large log sizes. Therefore, I hope that only the most critical parts are extracted and recorded when an error is logged here.

我已确认该 PR 已自测通过，相关截图如下：

![image](https://github.com/songquanpeng/one-api/assets/132346501/0b446ced-cfe5-4e73-a8de-50483ce83199)

