### PR TITLE
fix only extract and record the most critical part.

### DIFF
--- a/.github/workflows/docker-image-amd64.yml
+++ b/.github/workflows/docker-image-amd64.yml
@@ -1,61 +1,45 @@
-name: Publish Docker image (amd64)
+name: Publish Docker Image
 
 on:
-  push:
-    tags:
-      - '*'
   workflow_dispatch:
-    inputs:
-      name:
-        description: 'reason'
-        required: false
+  release:
+    types: [published]
+
 jobs:
-  push_to_registries:
-    name: Push Docker image to multiple registries
+  push_to_registry:
+    name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
-
-      - name: Check repository URL
-        run: |
-          REPO_URL=$(git config --get remote.origin.url)
-          if [[ $REPO_URL == *"pro" ]]; then
-            exit 1
-          fi        
-
-      - name: Save version info
-        run: |
-          git describe --tags > VERSION 
-
+        uses: actions/checkout@v4
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          images: |
-            justsong/one-api
-            ghcr.io/${{ github.repository }}
+          images: yangclivia/one-api
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
 
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-image-amd64.yml
+++ b/.github/workflows/docker-image-amd64.yml
@@ -1,45 +1,61 @@
-name: Publish Docker Image
+name: Publish Docker image (amd64)
 
 on:
+  push:
+    tags:
+      - '*'
   workflow_dispatch:
-  release:
-    types: [published]
-
+    inputs:
+      name:
+        description: 'reason'
+        required: false
 jobs:
-  push_to_registry:
-    name: Push Docker image to Docker Hub
+  push_to_registries:
+    name: Push Docker image to multiple registries
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
+
+      - name: Check repository URL
+        run: |
+          REPO_URL=$(git config --get remote.origin.url)
+          if [[ $REPO_URL == *"pro" ]]; then
+            exit 1
+          fi        
+
+      - name: Save version info
+        run: |
+          git describe --tags > VERSION 
+
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v4
         with:
-          images: yangclivia/one-api
-          tags: |
-            type=raw,value=latest
-            type=ref,event=tag
+          images: |
+            justsong/one-api
+            ghcr.io/${{ github.repository }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/relay/channel/openai/token.go
+++ b/relay/channel/openai/token.go
@@ -130,6 +130,9 @@ const (
 // https://platform.openai.com/docs/guides/vision/calculating-costs
 // https://github.com/openai/openai-cookbook/blob/05e3f9be4c7a2ae7ecf029a7c32065b024730ebe/examples/How_to_count_tokens_with_tiktoken.ipynb
 func countImageTokens(url string, detail string) (_ int, err error) {
+	if !strings.HasPrefix(url, "data:image") {
+        return 0, errors.New("invalid image file type")
+    }
 	var fetchSize = true
 	var width, height int
 	// Reference: https://platform.openai.com/docs/guides/vision/low-or-high-fidelity-image-understanding

--- a/relay/channel/openai/token.go
+++ b/relay/channel/openai/token.go
@@ -102,7 +102,8 @@ func CountTokenMessages(messages []model.Message, model string) int {
 						}
 						imageTokens, err := countImageTokens(url, detail)
 						if err != nil {
-							logger.SysError("error counting image tokens: " + err.Error())
+							//Due to the excessive length of the error information, only extract and record the most critical part.
+							logger.SysError(fmt.Sprintf("error counting image tokens. Error type: %T", err))
 						} else {
 							tokenNum += imageTokens
 						}


### PR DESCRIPTION
### Because sometimes when certain models transfer files, the error information here becomes too long, leading to very large log sizes. Therefore, I hope that only the most critical parts are extracted and recorded when an error is logged here.

我已确认该 PR 已自测通过，相关截图如下：
<img width="578" alt="2c1992dc6791eef89d324d90eb04106" src="https://github.com/songquanpeng/one-api/assets/132346501/bbd81b95-d83a-4b7e-8660-d96ba0941e3f">
