### PR TITLE
零一万物的模型价格错误了

### DIFF
--- a/common/model-ratio.go
+++ b/common/model-ratio.go
@@ -133,9 +133,9 @@ var ModelRatio = map[string]float64{
 	"mixtral-8x7b-32768": 0.27 / 1000 * USD,
 	"gemma-7b-it":        0.1 / 1000 * USD,
 	// https://platform.lingyiwanwu.com/docs#-计费单元
-	"yi-34b-chat-0205": 2.5 / 1000000 * RMB,
-	"yi-34b-chat-200k": 12.0 / 1000000 * RMB,
-	"yi-vl-plus":       6.0 / 1000000 * RMB,
+	"yi-34b-chat-0205": 2.5 / 1000 * RMB,
+	"yi-34b-chat-200k": 12.0 / 1000 * RMB,
+	"yi-vl-plus":       6.0 / 1000 * RMB,
 }
 
 var CompletionRatio = map[string]float64{}


### PR DESCRIPTION
[//]: # (请按照以下格式关联 issue)
[//]: # (请在提交 PR 前确认所提交的功能可用，需要附上截图，谢谢)
[//]: # (项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解)
[//]: # (开发者交流群：910657413)
[//]: # (请在提交 PR 之前删除上面的注释)
![image](https://github.com/songquanpeng/one-api/assets/137054651/be663d11-c335-46ca-913c-d4c32ac50e1b)
上面是官方的文档，以第一个模型为例  2.5/7/1000/0.002=0.178571  代码中计算的时候不应该除以1000000而是1000
close #issue_number

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
