### PR TITLE
feat: save and query request client ip for relay router（）; fix air theme bugs at log page;

### DIFF
--- a/controller/log.go
+++ b/controller/log.go
@@ -20,7 +20,8 @@ func GetAllLogs(c *gin.Context) {
 	tokenName := c.Query("token_name")
 	modelName := c.Query("model_name")
 	channel, _ := strconv.Atoi(c.Query("channel"))
-	logs, err := model.GetAllLogs(logType, startTimestamp, endTimestamp, modelName, username, tokenName, p*config.ItemsPerPage, config.ItemsPerPage, channel)
+	clientIP := c.Query("client_ip")
+	logs, err := model.GetAllLogs(logType, startTimestamp, endTimestamp, modelName, username, tokenName, p*config.ItemsPerPage, config.ItemsPerPage, channel, clientIP)
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,

--- a/model/log.go
+++ b/model/log.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"fmt"
+
 	"github.com/songquanpeng/one-api/common"
 	"github.com/songquanpeng/one-api/common/config"
 	"github.com/songquanpeng/one-api/common/helper"
@@ -24,6 +25,7 @@ type Log struct {
 	PromptTokens     int    `json:"prompt_tokens" gorm:"default:0"`
 	CompletionTokens int    `json:"completion_tokens" gorm:"default:0"`
 	ChannelId        int    `json:"channel" gorm:"index"`
+	ClientIP         string `json:"client_ip" gorm:"index;default:''"`
 }
 
 const (
@@ -51,7 +53,7 @@ func RecordLog(userId int, logType int, content string) {
 	}
 }
 
-func RecordConsumeLog(ctx context.Context, userId int, channelId int, promptTokens int, completionTokens int, modelName string, tokenName string, quota int64, content string) {
+func RecordConsumeLog(ctx context.Context, userId int, channelId int, promptTokens int, completionTokens int, modelName string, tokenName string, quota int64, content string, clientIP string) {
 	logger.Info(ctx, fmt.Sprintf("record consume log: userId=%d, channelId=%d, promptTokens=%d, completionTokens=%d, modelName=%s, tokenName=%s, quota=%d, content=%s", userId, channelId, promptTokens, completionTokens, modelName, tokenName, quota, content))
 	if !config.LogConsumeEnabled {
 		return
@@ -68,6 +70,7 @@ func RecordConsumeLog(ctx context.Context, userId int, channelId int, promptToke
 		ModelName:        modelName,
 		Quota:            int(quota),
 		ChannelId:        channelId,
+		ClientIP:         clientIP,
 	}
 	err := LOG_DB.Create(log).Error
 	if err != nil {
@@ -75,7 +78,7 @@ func RecordConsumeLog(ctx context.Context, userId int, channelId int, promptToke
 	}
 }
 
-func GetAllLogs(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, startIdx int, num int, channel int) (logs []*Log, err error) {
+func GetAllLogs(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, startIdx int, num int, channel int, clientIP string) (logs []*Log, err error) {
 	var tx *gorm.DB
 	if logType == LogTypeUnknown {
 		tx = LOG_DB
@@ -100,6 +103,10 @@ func GetAllLogs(logType int, startTimestamp int64, endTimestamp int64, modelName
 	if channel != 0 {
 		tx = tx.Where("channel_id = ?", channel)
 	}
+	if clientIP != "" {
+		tx = tx.Where("client_ip = ?", clientIP)
+	}
+
 	err = tx.Order("id desc").Limit(num).Offset(startIdx).Find(&logs).Error
 	return logs, err
 }

--- a/relay/controller/audio.go
+++ b/relay/controller/audio.go
@@ -7,6 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/songquanpeng/one-api/common"
 	"github.com/songquanpeng/one-api/common/config"
@@ -16,9 +20,6 @@ import (
 	"github.com/songquanpeng/one-api/relay/constant"
 	relaymodel "github.com/songquanpeng/one-api/relay/model"
 	"github.com/songquanpeng/one-api/relay/util"
-	"io"
-	"net/http"
-	"strings"
 )
 
 func RelayAudioHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatusCode {
@@ -99,6 +100,9 @@ func RelayAudioHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 
 	baseURL := common.ChannelBaseURLs[channelType]
 	requestURL := c.Request.URL.String()
+	clientIP := c.ClientIP()
+	fmt.Println(clientIP)
+
 	if c.GetString("base_url") != "" {
 		baseURL = c.GetString("base_url")
 	}
@@ -204,7 +208,7 @@ func RelayAudioHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 	}
 	quotaDelta := quota - preConsumedQuota
 	defer func(ctx context.Context) {
-		go util.PostConsumeQuota(ctx, tokenId, quotaDelta, quota, userId, channelId, modelRatio, groupRatio, audioModel, tokenName)
+		go util.PostConsumeQuota(ctx, tokenId, quotaDelta, quota, userId, channelId, modelRatio, groupRatio, audioModel, tokenName, clientIP)
 	}(c.Request.Context())
 
 	for k, v := range resp.Header {

--- a/relay/controller/helper.go
+++ b/relay/controller/helper.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/songquanpeng/one-api/common"
 	"github.com/songquanpeng/one-api/common/config"
@@ -13,8 +16,6 @@ import (
 	"github.com/songquanpeng/one-api/relay/constant"
 	relaymodel "github.com/songquanpeng/one-api/relay/model"
 	"github.com/songquanpeng/one-api/relay/util"
-	"math"
-	"net/http"
 )
 
 func getAndValidateTextRequest(c *gin.Context, relayMode int) (*relaymodel.GeneralOpenAIRequest, error) {
@@ -144,7 +145,7 @@ func preConsumeQuota(ctx context.Context, textRequest *relaymodel.GeneralOpenAIR
 	return preConsumedQuota, nil
 }
 
-func postConsumeQuota(ctx context.Context, usage *relaymodel.Usage, meta *util.RelayMeta, textRequest *relaymodel.GeneralOpenAIRequest, ratio float64, preConsumedQuota int64, modelRatio float64, groupRatio float64) {
+func postConsumeQuota(ctx context.Context, usage *relaymodel.Usage, meta *util.RelayMeta, textRequest *relaymodel.GeneralOpenAIRequest, ratio float64, preConsumedQuota int64, modelRatio float64, groupRatio float64, clientIP string) {
 	if usage == nil {
 		logger.Error(ctx, "usage is nil, which is unexpected")
 		return
@@ -173,7 +174,7 @@ func postConsumeQuota(ctx context.Context, usage *relaymodel.Usage, meta *util.R
 		logger.Error(ctx, "error update user quota cache: "+err.Error())
 	}
 	logContent := fmt.Sprintf("模型倍率 %.2f，分组倍率 %.2f，补全倍率 %.2f", modelRatio, groupRatio, completionRatio)
-	model.RecordConsumeLog(ctx, meta.UserId, meta.ChannelId, promptTokens, completionTokens, textRequest.Model, meta.TokenName, quota, logContent)
+	model.RecordConsumeLog(ctx, meta.UserId, meta.ChannelId, promptTokens, completionTokens, textRequest.Model, meta.TokenName, quota, logContent, clientIP)
 	model.UpdateUserUsedQuotaAndRequestCount(meta.UserId, quota)
 	model.UpdateChannelUsedQuota(meta.ChannelId, quota)
 }

--- a/relay/controller/image.go
+++ b/relay/controller/image.go
@@ -6,6 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
 	"github.com/songquanpeng/one-api/common"
 	"github.com/songquanpeng/one-api/common/logger"
 	"github.com/songquanpeng/one-api/model"
@@ -13,9 +17,6 @@ import (
 	"github.com/songquanpeng/one-api/relay/constant"
 	relaymodel "github.com/songquanpeng/one-api/relay/model"
 	"github.com/songquanpeng/one-api/relay/util"
-	"io"
-	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -132,7 +133,7 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		if quota != 0 {
 			tokenName := c.GetString("token_name")
 			logContent := fmt.Sprintf("模型倍率 %.2f，分组倍率 %.2f", modelRatio, groupRatio)
-			model.RecordConsumeLog(ctx, meta.UserId, meta.ChannelId, 0, 0, imageRequest.Model, tokenName, quota, logContent)
+			model.RecordConsumeLog(ctx, meta.UserId, meta.ChannelId, 0, 0, imageRequest.Model, tokenName, quota, logContent, c.ClientIP())
 			model.UpdateUserUsedQuotaAndRequestCount(meta.UserId, quota)
 			channelId := c.GetInt("channel_id")
 			model.UpdateChannelUsedQuota(channelId, quota)

--- a/relay/controller/text.go
+++ b/relay/controller/text.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/songquanpeng/one-api/common"
 	"github.com/songquanpeng/one-api/common/logger"
@@ -12,9 +16,6 @@ import (
 	"github.com/songquanpeng/one-api/relay/helper"
 	"github.com/songquanpeng/one-api/relay/model"
 	"github.com/songquanpeng/one-api/relay/util"
-	"io"
-	"net/http"
-	"strings"
 )
 
 func RelayTextHelper(c *gin.Context) *model.ErrorWithStatusCode {
@@ -99,6 +100,6 @@ func RelayTextHelper(c *gin.Context) *model.ErrorWithStatusCode {
 		return respErr
 	}
 	// post-consume quota
-	go postConsumeQuota(ctx, usage, meta, textRequest, ratio, preConsumedQuota, modelRatio, groupRatio)
+	go postConsumeQuota(ctx, usage, meta, textRequest, ratio, preConsumedQuota, modelRatio, groupRatio, c.ClientIP())
 	return nil
 }

--- a/relay/util/common.go
+++ b/relay/util/common.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
 	"github.com/songquanpeng/one-api/common"
 	"github.com/songquanpeng/one-api/common/config"
 	"github.com/songquanpeng/one-api/common/logger"
 	"github.com/songquanpeng/one-api/model"
 	relaymodel "github.com/songquanpeng/one-api/relay/model"
-	"io"
-	"net/http"
-	"strconv"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -155,7 +156,7 @@ func GetFullRequestURL(baseURL string, requestURL string, channelType int) strin
 	return fullRequestURL
 }
 
-func PostConsumeQuota(ctx context.Context, tokenId int, quotaDelta int64, totalQuota int64, userId int, channelId int, modelRatio float64, groupRatio float64, modelName string, tokenName string) {
+func PostConsumeQuota(ctx context.Context, tokenId int, quotaDelta int64, totalQuota int64, userId int, channelId int, modelRatio float64, groupRatio float64, modelName string, tokenName string, clientIP string) {
 	// quotaDelta is remaining quota to be consumed
 	err := model.PostConsumeTokenQuota(tokenId, quotaDelta)
 	if err != nil {
@@ -168,7 +169,7 @@ func PostConsumeQuota(ctx context.Context, tokenId int, quotaDelta int64, totalQ
 	// totalQuota is total quota consumed
 	if totalQuota != 0 {
 		logContent := fmt.Sprintf("模型倍率 %.2f，分组倍率 %.2f", modelRatio, groupRatio)
-		model.RecordConsumeLog(ctx, userId, channelId, int(totalQuota), 0, modelName, tokenName, totalQuota, logContent)
+		model.RecordConsumeLog(ctx, userId, channelId, int(totalQuota), 0, modelName, tokenName, totalQuota, logContent, clientIP)
 		model.UpdateUserUsedQuotaAndRequestCount(userId, totalQuota)
 		model.UpdateChannelUsedQuota(channelId, totalQuota)
 	}

--- a/web/air/src/helpers/utils.js
+++ b/web/air/src/helpers/utils.js
@@ -231,3 +231,7 @@ export function shouldShowPrompt(id) {
 export function setPromptShown(id) {
   localStorage.setItem(`prompt-${id}`, 'true');
 }
+
+export function safeGetLocalTimestamp(timeString) {
+  return timeString ? Date.parse(timeString) / 1000 : ''
+}

--- a/web/berry/src/views/Log/component/TableHead.js
+++ b/web/berry/src/views/Log/component/TableHead.js
@@ -14,6 +14,7 @@ const LogTableHead = ({ userIsAdmin }) => {
         <TableCell>提示</TableCell>
         <TableCell>补全</TableCell>
         <TableCell>额度</TableCell>
+        <TableCell>请求端IP</TableCell>
         <TableCell>详情</TableCell>
       </TableRow>
     </TableHead>

--- a/web/berry/src/views/Log/component/TableRow.js
+++ b/web/berry/src/views/Log/component/TableRow.js
@@ -57,6 +57,7 @@ export default function LogTableRow({ item, userIsAdmin }) {
         <TableCell>{item.prompt_tokens || ''}</TableCell>
         <TableCell>{item.completion_tokens || ''}</TableCell>
         <TableCell>{item.quota ? renderQuota(item.quota, 6) : ''}</TableCell>
+        <TableCell>{item.client_ip || ''}</TableCell>
         <TableCell>{item.content}</TableCell>
       </TableRow>
     </>

--- a/web/berry/src/views/Log/component/TableToolBar.js
+++ b/web/berry/src/views/Log/component/TableToolBar.js
@@ -5,6 +5,7 @@ import {
   IconKey,
   IconBrandGithubCopilot,
   IconSitemap,
+  IconMapPin
 } from "@tabler/icons-react";
 import {
   InputAdornment,
@@ -72,6 +73,30 @@ export default function TableToolBar({
             startAdornment={
               <InputAdornment position="start">
                 <IconBrandGithubCopilot
+                  stroke={1.5}
+                  size="20px"
+                  color={grey500}
+                />
+              </InputAdornment>
+            }
+          />
+        </FormControl>
+
+        <FormControl>
+          <InputLabel htmlFor="channel-client_ip-label">请求端IP</InputLabel>
+          <OutlinedInput
+            id="client_ip"
+            name="client_ip"
+            sx={{
+              minWidth: "100%",
+            }}
+            label="请求端IP"
+            value={filterName.client_ip}
+            onChange={handleFilterName}
+            placeholder="请求端IP"
+            startAdornment={
+              <InputAdornment position="start">
+                <IconMapPin
                   stroke={1.5}
                   size="20px"
                   color={grey500}

--- a/web/berry/src/views/Log/index.js
+++ b/web/berry/src/views/Log/index.js
@@ -28,7 +28,8 @@ export default function Log() {
     start_timestamp: 0,
     end_timestamp: new Date().getTime() / 1000 + 3600,
     type: 0,
-    channel: ''
+    channel: '',
+    client_ip: ''
   };
   const [logs, setLogs] = useState([]);
   const [activePage, setActivePage] = useState(0);

--- a/web/default/src/components/LogsTable.js
+++ b/web/default/src/components/LogsTable.js
@@ -57,9 +57,10 @@ const LogsTable = () => {
     model_name: '',
     start_timestamp: timestamp2string(0),
     end_timestamp: timestamp2string(now.getTime() / 1000 + 3600),
-    channel: ''
+    channel: '',
+    client_ip: ''
   });
-  const { username, token_name, model_name, start_timestamp, end_timestamp, channel } = inputs;
+  const { username, token_name, model_name, start_timestamp, end_timestamp, channel, client_ip } = inputs;
 
   const [stat, setStat] = useState({
     quota: 0,
@@ -73,7 +74,9 @@ const LogsTable = () => {
   const getLogSelfStat = async () => {
     let localStartTimestamp = Date.parse(start_timestamp) / 1000;
     let localEndTimestamp = Date.parse(end_timestamp) / 1000;
-    let res = await API.get(`/api/log/self/stat?type=${logType}&token_name=${token_name}&model_name=${model_name}&start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}`);
+    let res = await API.get(
+      `/api/log/self/stat?type=${logType}&token_name=${token_name}&model_name=${model_name}&client_ip=${client_ip}&start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}`
+    );
     const { success, message, data } = res.data;
     if (success) {
       setStat(data);
@@ -85,7 +88,9 @@ const LogsTable = () => {
   const getLogStat = async () => {
     let localStartTimestamp = Date.parse(start_timestamp) / 1000;
     let localEndTimestamp = Date.parse(end_timestamp) / 1000;
-    let res = await API.get(`/api/log/stat?type=${logType}&username=${username}&token_name=${token_name}&model_name=${model_name}&start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}&channel=${channel}`);
+    let res = await API.get(
+      `/api/log/stat?type=${logType}&username=${username}&token_name=${token_name}&model_name=${model_name}&client_ip=${client_ip}&start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}&channel=${channel}`
+    );
     const { success, message, data } = res.data;
     if (success) {
       setStat(data);
@@ -110,9 +115,9 @@ const LogsTable = () => {
     let localStartTimestamp = Date.parse(start_timestamp) / 1000;
     let localEndTimestamp = Date.parse(end_timestamp) / 1000;
     if (isAdminUser) {
-      url = `/api/log/?p=${startIdx}&type=${logType}&username=${username}&token_name=${token_name}&model_name=${model_name}&start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}&channel=${channel}`;
+      url = `/api/log/?p=${startIdx}&type=${logType}&username=${username}&token_name=${token_name}&model_name=${model_name}&client_ip=${client_ip}&start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}&channel=${channel}`;
     } else {
-      url = `/api/log/self/?p=${startIdx}&type=${logType}&token_name=${token_name}&model_name=${model_name}&start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}`;
+      url = `/api/log/self/?p=${startIdx}&type=${logType}&token_name=${token_name}&model_name=${model_name}&client_ip=${client_ip}&start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}`;
     }
     const res = await API.get(url);
     const { success, message, data } = res.data;
@@ -210,6 +215,9 @@ const LogsTable = () => {
                         placeholder={'可选值'} name='token_name' onChange={handleInputChange} />
             <Form.Input fluid label='模型名称' width={3} value={model_name} placeholder='可选值'
                         name='model_name'
+                        onChange={handleInputChange} />
+            <Form.Input fluid label='请求端IP' width={3} value={client_ip} placeholder='可选值'
+                        name='client_ip'
                         onChange={handleInputChange} />
             <Form.Input fluid label='起始时间' width={4} value={start_timestamp} type='datetime-local'
                         name='start_timestamp'
@@ -320,6 +328,15 @@ const LogsTable = () => {
                 width={1}
               >
                 额度
+              </Table.HeaderCell>
+              <Table.HeaderCell
+                style={{ cursor: 'pointer' }}
+                onClick={() => {
+                  sortLog('client_ip');
+                }}
+                width={1}
+              >
+                请求端IP
               </Table.HeaderCell>
               <Table.HeaderCell
                 style={{ cursor: 'pointer' }}


### PR DESCRIPTION
**改动项：**
1. 增加记录请求端IP的目的是：在把 one-api 部署到公司内部使用的场景下，会有根据 IP 排查问题的需求。控制台日志看到也输出了 IP，使用起来没有这么方便。
（已经适配了目前三个主题）
2. air 主题适配期间发现了一些前端bug，目前解决了两个：
2.1 日志页面，如果不选择任何时间范围，前端会错误地解析成NaN（修复，没有选择，使用空字符串）
2.2 日志页面，日志类型选择了其他值后，点击查询按钮，发现仍旧使用默认类型（修复，会使用当前用户选择的日志类型）

我已确认该 PR 已自测通过，相关截图如下：
**default:**
![telegram-cloud-photo-size-1-5168146392684801428-y](https://github.com/songquanpeng/one-api/assets/16076993/131d272b-2bd4-4aa6-a4ca-cbfc5e3d7747)
![telegram-cloud-photo-size-1-5168146392684801429-y](https://github.com/songquanpeng/one-api/assets/16076993/f12a88b9-3d3c-4b0f-bce2-50f277ec3bfc)
**berry:**
![telegram-cloud-photo-size-1-5168031270381399995-y](https://github.com/songquanpeng/one-api/assets/16076993/1c85c9fd-f233-451c-964f-90c8a8073bf7)
![telegram-cloud-photo-size-1-5168146392684801427-y](https://github.com/songquanpeng/one-api/assets/16076993/036afd64-9629-44d6-9a9c-0a3dd2380962)
**air:** 
![telegram-cloud-photo-size-1-5168031270381399994-y](https://github.com/songquanpeng/one-api/assets/16076993/f4db0028-19ab-472c-b4d2-6cd42a81bcde)

