### PR TITLE
fix: update model-ratio.go 修正文心计费模型名称

### DIFF
--- a/common/model-ratio.go
+++ b/common/model-ratio.go
@@ -75,7 +75,7 @@ var ModelRatio = map[string]float64{
 	"ERNIE-Bot":       0.8572,     // ￥0.012 / 1k tokens
 	"ERNIE-Bot-turbo": 0.5715,     // ￥0.008 / 1k tokens
 	"ERNIE-Bot-4":     0.12 * RMB, // ￥0.12 / 1k tokens
-	"ERNIE-Bot-8k":    0.024 * RMB,
+	"ERNIE-Bot-8K":    0.024 * RMB,
 	"Embedding-V1":    0.1429, // ￥0.002 / 1k tokens
 	"bge-large-zh":    0.002 * RMB,
 	"bge-large-en":    0.002 * RMB,


### PR DESCRIPTION
统一文心计费模型名称

模型那里是大K，计费这里是小k

<img width="436" alt="Snipaste_2024-03-29_00-03-58" src="https://github.com/songquanpeng/one-api/assets/40858189/6dce284a-4ad1-4641-850b-907c611e5ff8">
