### PR TITLE
fix: fix getPreConsumedQuota

### DIFF
--- a/relay/controller/helper.go
+++ b/relay/controller/helper.go
@@ -124,9 +124,9 @@ func getPromptTokens(textRequest *relaymodel.GeneralOpenAIRequest, relayMode int
 }
 
 func getPreConsumedQuota(textRequest *relaymodel.GeneralOpenAIRequest, promptTokens int, ratio float64) int64 {
-	preConsumedTokens := config.PreConsumedQuota
+	preConsumedTokens := config.PreConsumedQuota + int64(promptTokens)
 	if textRequest.MaxTokens != 0 {
-		preConsumedTokens = int64(promptTokens) + int64(textRequest.MaxTokens)
+		preConsumedTokens += int64(textRequest.MaxTokens)
 	}
 	return int64(float64(preConsumedTokens) * ratio)
 }


### PR DESCRIPTION
目前如果 API 没有传递 max_tokens 参数，getPreConsumedQuota 就不会计算 prompt tokens，可能会造成超额使用的情况。比如我截图的这个例子，虽然我设置了请求预扣费额度，但是用户的这个请求产生的额度，远远超出了他账户剩余的额度，因为他用的客户端没有传递 max_tokens，getPreConsumedQuota 方法没有计算到 prompt tokens， 他的 prompt tokens 还非常长。

像 Claude 3 Opus 这种支持超长上下文，价格还不便宜的模型，如果用户传递超长的 prompt，不计算 prompt tokens 很容易被用户超额使用几美元。

我把 getPreConsumedQuota 改成了默认会计算 prompt tokens。

![image](https://github.com/songquanpeng/one-api/assets/18375001/d6532576-f88c-4f45-a760-a0201bdc3732)
![image](https://github.com/songquanpeng/one-api/assets/18375001/02ecdb8e-2ed1-4d8f-9658-7048f2292e19)


close #issue_number

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
![image](https://github.com/songquanpeng/one-api/assets/18375001/f67296f2-0061-4c04-9e03-5c57e8d10692)
