### PR TITLE
fix: logger race

### DIFF
--- a/common/image/image.go
+++ b/common/image/image.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Regex to match data URL pattern
-var	dataURLPattern = regexp.MustCompile(`data:image/([^;]+);base64,(.*)`)
+var dataURLPattern = regexp.MustCompile(`data:image/([^;]+);base64,(.*)`)
 
 func IsImageUrl(url string) (bool, error) {
 	resp, err := http.Head(url)

--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -3,15 +3,16 @@ package logger
 import (
 	"context"
 	"fmt"
-	"github.com/gin-gonic/gin"
-	"github.com/songquanpeng/one-api/common/config"
-	"github.com/songquanpeng/one-api/common/helper"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/songquanpeng/one-api/common/config"
+	"github.com/songquanpeng/one-api/common/helper"
 )
 
 const (
@@ -21,28 +22,20 @@ const (
 	loggerError = "ERR"
 )
 
-var setupLogLock sync.Mutex
-var setupLogWorking bool
+var setupLogOnce sync.Once
 
 func SetupLogger() {
-	if LogDir != "" {
-		ok := setupLogLock.TryLock()
-		if !ok {
-			log.Println("setup log is already working")
-			return
+	setupLogOnce.Do(func() {
+		if LogDir != "" {
+			logPath := filepath.Join(LogDir, fmt.Sprintf("oneapi-%s.log", time.Now().Format("20060102")))
+			fd, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				log.Fatal("failed to open log file")
+			}
+			gin.DefaultWriter = io.MultiWriter(os.Stdout, fd)
+			gin.DefaultErrorWriter = io.MultiWriter(os.Stderr, fd)
 		}
-		defer func() {
-			setupLogLock.Unlock()
-			setupLogWorking = false
-		}()
-		logPath := filepath.Join(LogDir, fmt.Sprintf("oneapi-%s.log", time.Now().Format("20060102")))
-		fd, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			log.Fatal("failed to open log file")
-		}
-		gin.DefaultWriter = io.MultiWriter(os.Stdout, fd)
-		gin.DefaultErrorWriter = io.MultiWriter(os.Stderr, fd)
-	}
+	})
 }
 
 func SysLog(s string) {
@@ -100,12 +93,7 @@ func logHelper(ctx context.Context, level string, msg string) {
 	}
 	now := time.Now()
 	_, _ = fmt.Fprintf(writer, "[%s] %v | %s | %s \n", level, now.Format("2006/01/02 - 15:04:05"), id, msg)
-	if !setupLogWorking {
-		setupLogWorking = true
-		go func() {
-			SetupLogger()
-		}()
-	}
+	SetupLogger()
 }
 
 func FatalLog(v ...any) {


### PR DESCRIPTION
## 问题

logger 存在 data race。

## 解决办法

用 `sync.Once` 确保 `SetupLogger` 只运行一次

## 复现

用 `go run -race` 启动后，随便触发点错误日志，就会报大量 race。

```

[SYS] 2024/04/20 - 06:18:10 | One API v0.0.0 started 
[SYS] 2024/04/20 - 06:18:10 | SQL_DSN not set, using SQLite as database 
[SYS] 2024/04/20 - 06:18:10 | database migration started 
[SYS] 2024/04/20 - 06:18:10 | database migrated 
[SYS] 2024/04/20 - 06:18:10 | REDIS_CONN_STRING not set, Redis is not enabled 
[SYS] 2024/04/20 - 06:18:10 | using theme default 
[SYS] 2024/04/20 - 06:18:10 | initializing token encoders 
[SYS] 2024/04/20 - 06:18:10 | token encoders initialized 

2024/04/20 06:18:11 /home/laisky/repo/laisky/one-api/model/ability.go:37 record not found
[0.475ms] [rows:0] SELECT * FROM `abilities` WHERE `group` = "default" and model = "claude-3-haiku2" and enabled = 1 and priority = (SELECT MAX(priority) FROM `abilities` WHERE `group` = "default" and model = "claude-3-haiku2" and enabled = 1) ORDER BY RANDOM(),`abilities`.`group` LIMIT 1
[ERR] 2024/04/20 - 06:18:11 | 2024042006181170389917087530810 | 当前分组 default 下对于模型 claude-3-haiku2 无可用渠道 
[GIN] 2024/04/20 - 06:18:11 | 2024042006181170389917087530810 | 503 |    2.059767ms |   100.94.242.12 |    POST /v1/chat/completions

2024/04/20 06:18:16 /home/laisky/repo/laisky/one-api/model/ability.go:37 record not found
[0.206ms] [rows:0] SELECT * FROM `abilities` WHERE `group` = "default" and model = "claude-3-haiku2" and enabled = 1 and priority = (SELECT MAX(priority) FROM `abilities` WHERE `group` = "default" and model = "claude-3-haiku2" and enabled = 1) ORDER BY RANDOM(),`abilities`.`group` LIMIT 1
==================
WARNING: DATA RACE
Read at 0x0000026db2e0 by goroutine 30:
  github.com/songquanpeng/one-api/common/logger.logHelper()
      /home/laisky/repo/laisky/one-api/common/logger/logger.go:93 +0x64
  github.com/songquanpeng/one-api/common/logger.Error()
      /home/laisky/repo/laisky/one-api/common/logger/logger.go:73 +0x3c7
  github.com/songquanpeng/one-api/middleware.abortWithMessage()
      /home/laisky/repo/laisky/one-api/middleware/utils.go:20 +0x30f
  github.com/songquanpeng/one-api/router.SetRelayRouter.Distribute.func4()
      /home/laisky/repo/laisky/one-api/middleware/distributor.go:52 +0x355
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x92
  github.com/songquanpeng/one-api/router.SetRelayRouter.TokenAuth.func3()
      /home/laisky/repo/laisky/one-api/middleware/auth.go:142 +0x569
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x92
  github.com/songquanpeng/one-api/router.SetRelayRouter.RelayPanicRecover.func2()
      /home/laisky/repo/laisky/one-api/middleware/recover.go:31 +0x76
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x92
  main.main.Sessions.func3()
      /home/laisky/.go/pkg/mod/github.com/gin-contrib/sessions@v1.0.0/sessions.go:54 +0x304
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x215
  github.com/gin-gonic/gin.LoggerWithConfig.func1()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/logger.go:240 +0x191
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x92
  main.main.RequestId.func2()
      /home/laisky/repo/laisky/one-api/middleware/request-id.go:17 +0x168
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x15a
  github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/recovery.go:102 +0xd4
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0xbb5
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:620 +0x7b9
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:576 +0x418
  net/http.serverHandler.ServeHTTP()
      /opt/go1.22/src/net/http/server.go:3137 +0x2a1
  net/http.(*conn).serve()
      /opt/go1.22/src/net/http/server.go:2039 +0x13c4
  net/http.(*Server).Serve.gowrap3()
      /opt/go1.22/src/net/http/server.go:3285 +0x4f

Previous write at 0x0000026db2e0 by goroutine 32:
  github.com/songquanpeng/one-api/common/logger.SetupLogger()
      /home/laisky/repo/laisky/one-api/common/logger/logger.go:44 +0xa08
  github.com/songquanpeng/one-api/common/logger.logHelper.func1()
      /home/laisky/repo/laisky/one-api/common/logger/logger.go:106 +0x1c

Goroutine 30 (running) created at:
  net/http.(*Server).Serve()
      /opt/go1.22/src/net/http/server.go:3285 +0x8ec
  net/http.(*Server).ListenAndServe()
      /opt/go1.22/src/net/http/server.go:3184 +0xbc
  net/http.ListenAndServe()
      /opt/go1.22/src/net/http/server.go:3438 +0x3a7
  github.com/gin-gonic/gin.(*Engine).Run()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:386 +0x1a5
  main.main()
      /home/laisky/repo/laisky/one-api/main.go:114 +0xe5e

Goroutine 32 (finished) created at:
  github.com/songquanpeng/one-api/common/logger.logHelper()
      /home/laisky/repo/laisky/one-api/common/logger/logger.go:105 +0x28c
  github.com/songquanpeng/one-api/common/logger.Error()
      /home/laisky/repo/laisky/one-api/common/logger/logger.go:73 +0x3c7
  github.com/songquanpeng/one-api/middleware.abortWithMessage()
      /home/laisky/repo/laisky/one-api/middleware/utils.go:20 +0x30f
  github.com/songquanpeng/one-api/router.SetRelayRouter.Distribute.func4()
      /home/laisky/repo/laisky/one-api/middleware/distributor.go:52 +0x355
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x92
  github.com/songquanpeng/one-api/router.SetRelayRouter.TokenAuth.func3()
      /home/laisky/repo/laisky/one-api/middleware/auth.go:142 +0x569
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x92
  github.com/songquanpeng/one-api/router.SetRelayRouter.RelayPanicRecover.func2()
      /home/laisky/repo/laisky/one-api/middleware/recover.go:31 +0x76
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x92
  main.main.Sessions.func3()
      /home/laisky/.go/pkg/mod/github.com/gin-contrib/sessions@v1.0.0/sessions.go:54 +0x304
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x215
  github.com/gin-gonic/gin.LoggerWithConfig.func1()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/logger.go:240 +0x191
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x92
  main.main.RequestId.func2()
      /home/laisky/repo/laisky/one-api/middleware/request-id.go:17 +0x168
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x15a
  github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/recovery.go:102 +0xd4
  github.com/gin-gonic/gin.(*Context).Next()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0xbb5
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:620 +0x7b9
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /home/laisky/.go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:576 +0x418
  net/http.serverHandler.ServeHTTP()
      /opt/go1.22/src/net/http/server.go:3137 +0x2a1
  net/http.(*conn).serve()
      /opt/go1.22/src/net/http/server.go:2039 +0x13c4
  net/http.(*Server).Serve.gowrap3()
      /opt/go1.22/src/net/http/server.go:3285 +0x4f
==================

``` 