### PR TITLE
fix: fix default theme blank screen when edit channel again

### DIFF
--- a/web/default/src/pages/Channel/EditChannel.js
+++ b/web/default/src/pages/Channel/EditChannel.js
@@ -174,7 +174,7 @@ const EditChannel = () => {
       showInfo('模型映射必须是合法的 JSON 格式！');
       return;
     }
-    let localInputs = inputs;
+    let localInputs = JSON.parse(JSON.stringify(inputs));
     if (localInputs.base_url && localInputs.base_url.endsWith('/')) {
       localInputs.base_url = localInputs.base_url.slice(0, localInputs.base_url.length - 1);
     }

--- a/web/default/src/pages/Channel/EditChannel.js
+++ b/web/default/src/pages/Channel/EditChannel.js
@@ -174,7 +174,7 @@ const EditChannel = () => {
       showInfo('模型映射必须是合法的 JSON 格式！');
       return;
     }
-    let localInputs = JSON.parse(JSON.stringify(inputs));
+    let localInputs = {...inputs};
     if (localInputs.base_url && localInputs.base_url.endsWith('/')) {
       localInputs.base_url = localInputs.base_url.slice(0, localInputs.base_url.length - 1);
     }


### PR DESCRIPTION
问题描述：在编辑渠道时，提交编辑内容后，再次编辑会触发 JS 异常导致页面白屏，异常内容：
<img width="443" alt="image" src="https://github.com/songquanpeng/one-api/assets/1974874/f1c65918-29fc-4122-9c60-4ce7dd939f3a">

原因是在 submit 时，误将 `.join(,)`后的结果保存到 state 中，修改了数据类型导致。

我已确认该 PR 已自测通过，相关截图如下：

异常：
https://github.com/songquanpeng/one-api/assets/1974874/387159d9-da11-4fdd-b288-82f046817249
修复后：
https://github.com/songquanpeng/one-api/assets/1974874/f5ea85b3-1258-4d02-a500-c1ba301c52e0


