### PR TITLE
feat: use mapped model name to test

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -5,6 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/songquanpeng/one-api/common/config"
 	"github.com/songquanpeng/one-api/common/ctxkey"
 	"github.com/songquanpeng/one-api/common/logger"
@@ -18,14 +27,6 @@ import (
 	"github.com/songquanpeng/one-api/relay/meta"
 	relaymodel "github.com/songquanpeng/one-api/relay/model"
 	"github.com/songquanpeng/one-api/relay/relaymode"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -67,6 +68,7 @@ func testChannel(channel *model.Channel) (err error, openaiErr *relaymodel.Error
 	adaptor.Init(meta)
 	var modelName string
 	modelList := adaptor.GetModelList()
+	modelMap := channel.GetModelMapping()
 	if len(modelList) != 0 {
 		modelName = modelList[0]
 	}
@@ -74,6 +76,9 @@ func testChannel(channel *model.Channel) (err error, openaiErr *relaymodel.Error
 		modelNames := strings.Split(channel.Models, ",")
 		if len(modelNames) > 0 {
 			modelName = modelNames[0]
+		}
+		if modelMap != nil && modelMap[modelName] != "" {
+			modelName = modelMap[modelName]
 		}
 	}
 	request := buildTestRequest()


### PR DESCRIPTION
描述：渠道测试会使用第一个模型名来发起请求，如果使用模型重定向来保证各个渠道对外提供的模型名称一致，而第一个模型的名称又不是该渠道真正可用的模型名时可能会报错。

如下图，使用模型重定向将 Nvidia API 的 `meta/llama3-70b-instruct` 映射为 `llama-3-70b-instruct`，测试时会使用  `llama-3-70b-instruct` 作为模型名称，期望是使用`meta/llama3-70b-instruct`。
<img width="806" alt="image" src="https://github.com/songquanpeng/one-api/assets/1974874/7d002125-2dec-44e6-a4fb-7b4470053697">
我已确认该 PR 已自测通过，相关截图如下：

```
[SYS] 2024/04/25 - 13:29:16 | {"messages":[{"role":"user","content":"hi"}],"model":"meta/llama3-70b-instruct","max_tokens":2} 
[SYS] 2024/04/25 - 13:29:17 | testing channel #2, response: 
{"id":"chatcmpl-2175002b-36fa-43bc-aafc-809e3f84c498","object":"chat.completion","created":1714022957,"model":"meta/llama3-70b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hi!"},"logprobs":{"content":[{"logprob":0.0},{"logprob":0.0}]}}],"usage":{"prompt_tokens":11,"total_tokens":13,"completion_tokens":2}} 
```
