### PR TITLE
fix: refactor Gemini adaptor to support streaming content generation

### DIFF
--- a/relay/adaptor/gemini/adaptor.go
+++ b/relay/adaptor/gemini/adaptor.go
@@ -3,6 +3,9 @@ package gemini
 import (
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/songquanpeng/one-api/common/config"
 	"github.com/songquanpeng/one-api/common/helper"
@@ -10,8 +13,6 @@ import (
 	"github.com/songquanpeng/one-api/relay/adaptor/openai"
 	"github.com/songquanpeng/one-api/relay/meta"
 	"github.com/songquanpeng/one-api/relay/model"
-	"io"
-	"net/http"
 )
 
 type Adaptor struct {
@@ -25,7 +26,7 @@ func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
 	version := helper.AssignOrDefault(meta.Config.APIVersion, config.GeminiVersion)
 	action := "generateContent"
 	if meta.IsStream {
-		action = "streamGenerateContent"
+		action = "streamGenerateContent?alt=sse"
 	}
 	return fmt.Sprintf("%s/%s/models/%s:%s", meta.BaseURL, version, meta.ActualModelName, action), nil
 }

--- a/relay/adaptor/gemini/main.go
+++ b/relay/adaptor/gemini/main.go
@@ -232,8 +232,6 @@ func streamResponseGeminiChat2OpenAI(geminiResponse *ChatResponse) *openai.ChatC
 
 func StreamHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusCode, string) {
 	responseText := ""
-	dataChan := make(chan string)
-	stopChan := make(chan bool)
 	scanner := bufio.NewScanner(resp.Body)
 	scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		if atEOF && len(data) == 0 {
@@ -247,14 +245,16 @@ func StreamHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusC
 		}
 		return 0, nil, nil
 	})
+	dataChan := make(chan string)
+	stopChan := make(chan bool)
 	go func() {
 		for scanner.Scan() {
 			data := scanner.Text()
 			data = strings.TrimSpace(data)
-			if !strings.HasPrefix(data, "\"text\": \"") {
+			if !strings.HasPrefix(data, "data: ") {
 				continue
 			}
-			data = strings.TrimPrefix(data, "\"text\": \"")
+			data = strings.TrimPrefix(data, "data: ")
 			data = strings.TrimSuffix(data, "\"")
 			dataChan <- data
 		}
@@ -264,23 +264,17 @@ func StreamHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusC
 	c.Stream(func(w io.Writer) bool {
 		select {
 		case data := <-dataChan:
-			// this is used to prevent annoying \ related format bug
-			data = fmt.Sprintf("{\"content\": \"%s\"}", data)
-			type dummyStruct struct {
-				Content string `json:"content"`
+			var geminiResponse ChatResponse
+			err := json.Unmarshal([]byte(data), &geminiResponse)
+			if err != nil {
+				logger.SysError("error unmarshalling stream response: " + err.Error())
+				return true
 			}
-			var dummy dummyStruct
-			err := json.Unmarshal([]byte(data), &dummy)
-			responseText += dummy.Content
-			var choice openai.ChatCompletionsStreamResponseChoice
-			choice.Delta.Content = dummy.Content
-			response := openai.ChatCompletionsStreamResponse{
-				Id:      fmt.Sprintf("chatcmpl-%s", random.GetUUID()),
-				Object:  "chat.completion.chunk",
-				Created: helper.GetTimestamp(),
-				Model:   "gemini-pro",
-				Choices: []openai.ChatCompletionsStreamResponseChoice{choice},
+			response := streamResponseGeminiChat2OpenAI(&geminiResponse)
+			if response == nil {
+				return true
 			}
+			responseText += fmt.Sprintf("%v", response.Choices[0].Delta.Content)
 			jsonResponse, err := json.Marshal(response)
 			if err != nil {
 				logger.SysError("error marshalling stream response: " + err.Error())


### PR DESCRIPTION
close #1345
close #1328

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
```
[SYS] 2024/04/27 - 12:13:57 | One API v0.0.0 started 
[SYS] 2024/04/27 - 12:13:57 | running in debug mode 
[SYS] 2024/04/27 - 12:13:57 | using MySQL as database 
[SYS] 2024/04/27 - 12:13:57 | database migration started 
[SYS] 2024/04/27 - 12:13:57 | database migrated 
[SYS] 2024/04/27 - 12:13:57 | REDIS_CONN_STRING not set, Redis is not enabled 
[SYS] 2024/04/27 - 12:13:57 | using theme berry 
[SYS] 2024/04/27 - 12:13:57 | initializing token encoders 
[SYS] 2024/04/27 - 12:13:57 | token encoders initialized 
[DEBUG] 2024/04/27 - 12:14:18 | 202404271214186411478132525273 | request body: {
    "model": "gemini-pro",
    "temperature": 0.12,
    "max_tokens": 2000,
    "stream": true,
    "messages": [
        {
            "role": "user",
            "content": "请详细分析最近的股市走势"
        }
    ]
} 
[SYS] 2024/04/27 - 12:14:18 | failed to get token encoder for model gemini-pro: no encoding for model gemini-pro, using encoder for gpt-3.5-turbo 
[DEBUG] 2024/04/27 - 12:14:18 | 202404271214186411478132525273 | converted request: 
{"contents":[{"role":"user","parts":[{"text":"请详细分析最近的股市走势"}]}],"safety_settings":[{"category":"HARM_CATEGORY_HARASSMENT","threshold":"BLOCK_NONE"},{"category":"HARM_CATEGORY_HATE_SPEECH","threshold":"BLOCK_NONE"},{"category":"HARM_CATEGORY_SEXUALLY_EXPLICIT","threshold":"BLOCK_NONE"},{"category":"HARM_CATEGORY_DANGEROUS_CONTENT","threshold":"BLOCK_NONE"}],"generation_config":{"temperature":0.12,"maxOutputTokens":2000}} 
[INFO] 2024/04/27 - 12:14:18 | 202404271214186411478132525273 | user 1 has enough quota 499999973113047, trusted and no need to pre-consume 
[GIN] 2024/04/27 - 12:14:28 | 202404271214186411478132525273 | 200 | 10.292869664s |   219.228.146.1 |    POST /v1/chat/completions
[INFO] 2024/04/27 - 12:14:28 | 202404271214186411478132525273 | record consume log: userId=1, channelId=4, promptTokens=23, completionTokens=977, modelName=gemini-pro, tokenName=FastChat, quota=2954, content=模型倍率 1.00，分组倍率 1.00，补全倍率 3.00 


```

![image](https://github.com/songquanpeng/one-api/assets/18144577/f3ef94c8-88d3-4efd-a326-184c7a76b410)

