### PR TITLE
feat: support /v1/rerank router

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -33,6 +33,8 @@ func relayHelper(c *gin.Context, relayMode int) *model.ErrorWithStatusCode {
 		fallthrough
 	case relaymode.AudioTranscription:
 		err = controller.RelayAudioHelper(c, relayMode)
+	case relaymode.Rerank:
+		err = controller.RerankHelper(c, relayMode)
 	default:
 		err = controller.RelayTextHelper(c)
 	}

--- a/relay/adaptor/openai/model.go
+++ b/relay/adaptor/openai/model.go
@@ -143,3 +143,27 @@ type CompletionsStreamResponse struct {
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
 }
+type Document struct {
+	Text string `json:"text"`
+}
+
+type DocumentResult struct {
+	Index    int       `json:"index"`
+	Score    float64   `json:"score"`
+	Document *Document `json:"document,omitempty"`
+}
+
+type RerankRequest struct {
+	Model           string     `json:"model"`
+	Query           string     `json:"query"`
+	Documents       []Document `json:"documents"`
+	TopN            *int       `json:"top_n,omitempty"`
+	MaxChunksPerDoc *int       `json:"max_chunks_per_doc,omitempty"`
+	ReturnDocuments bool       `json:"return_documents"`
+}
+
+type RerankResponse struct {
+	ID      string           `json:"id,omitempty"`
+	Results []DocumentResult `json:"results"`
+	Error   *string          `json:"error,omitempty"`
+}

--- a/relay/controller/helper.go
+++ b/relay/controller/helper.go
@@ -57,7 +57,37 @@ func getImageRequest(c *gin.Context, relayMode int) (*relaymodel.ImageRequest, e
 	}
 	return imageRequest, nil
 }
+func getRerankRequest(c *gin.Context, relayMode int) (*relaymodel.RerankRequest, error) {
+	rerankRequest := &relaymodel.RerankRequest{}
+	err := common.UnmarshalBodyReusable(c, rerankRequest)
+	if err != nil {
+		return nil, err
+	}
+	if rerankRequest.Model == "" {
+		return nil, errors.New("model parameter must be provided")
+	}
+	// Set default values if necessary
+	if rerankRequest.TopN == nil {
+		defaultTopN := 10 // Default to returning top 10 results
+		rerankRequest.TopN = &defaultTopN
+	}
+	if rerankRequest.Query == "" {
+		return nil, errors.New("query must not be empty")
+	}
+	if len(rerankRequest.Documents) == 0 {
+		return nil, errors.New("document list must not be empty")
+	}
+	// if rerankRequest.MaxChunksPerDoc == nil {
+	//     defaultMaxChunks := 5 // Default maximum chunks per document
+	//     rerankRequest.MaxChunksPerDoc = &defaultMaxChunks
+	// }
+	if rerankRequest.ReturnDocuments == nil {
+		defaultReturnDocs := true // Default to returning documents
+		rerankRequest.ReturnDocuments = &defaultReturnDocs
+	}
 
+	return rerankRequest, nil
+}
 func isValidImageSize(model string, size string) bool {
 	if model == "cogview-3" {
 		return true

--- a/relay/controller/rerank.go
+++ b/relay/controller/rerank.go
@@ -1,0 +1,62 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/songquanpeng/one-api/common/logger"
+	"github.com/songquanpeng/one-api/relay"
+	"github.com/songquanpeng/one-api/relay/adaptor/openai"
+	"github.com/songquanpeng/one-api/relay/meta"
+	relaymodel "github.com/songquanpeng/one-api/relay/model"
+	"io"
+	"net/http"
+)
+
+func RerankHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatusCode {
+	ctx := c.Request.Context()
+	meta := meta.GetByContext(c)
+	rerankRequest, err := getRerankRequest(c, meta.Mode)
+	if err != nil {
+		logger.Errorf(ctx, "getRerankRequest failed: %s", err.Error())
+		return openai.ErrorWrapper(err, "invalid_rerank_request", http.StatusBadRequest)
+	}
+
+	// Map model name
+	var isModelMapped bool
+	meta.OriginModelName = rerankRequest.Model
+	rerankRequest.Model, isModelMapped = getMappedModelName(rerankRequest.Model, meta.ModelMapping)
+	meta.ActualModelName = rerankRequest.Model
+
+	var requestBody io.Reader
+	if isModelMapped {
+		jsonStr, err := json.Marshal(rerankRequest)
+		if err != nil {
+			return openai.ErrorWrapper(err, "marshal_rerank_request_failed", http.StatusInternalServerError)
+		}
+		requestBody = bytes.NewBuffer(jsonStr)
+	} else {
+		requestBody = c.Request.Body
+	}
+
+	adaptor := relay.GetAdaptor(meta.APIType)
+	if adaptor == nil {
+		return openai.ErrorWrapper(fmt.Errorf("invalid api type: %d", meta.APIType), "invalid_api_type", http.StatusBadRequest)
+	}
+
+	resp, err := adaptor.DoRequest(c, meta, requestBody)
+	if err != nil {
+		logger.Errorf(ctx, "DoRequest failed: %s", err.Error())
+		return openai.ErrorWrapper(err, "do_request_failed", http.StatusInternalServerError)
+	}
+
+	// do response
+	_, respErr := adaptor.DoResponse(c, resp, meta)
+	if respErr != nil {
+		logger.Errorf(ctx, "respErr is not nil: %+v", respErr)
+		return respErr
+	}
+
+	return nil
+}

--- a/relay/model/rerank.go
+++ b/relay/model/rerank.go
@@ -1,0 +1,10 @@
+package model
+
+type RerankRequest struct {
+	Model           string   `json:"model"`
+	Documents       []string `json:"documents"`
+	Query           string   `json:"query"`
+	TopN            *int     `json:"top_n,omitempty"`
+	MaxChunksPerDoc *int     `json:"max_chunks_per_doc,omitempty"`
+	ReturnDocuments *bool    `json:"return_documents,omitempty"`
+}

--- a/relay/relaymode/define.go
+++ b/relay/relaymode/define.go
@@ -11,4 +11,5 @@ const (
 	AudioSpeech
 	AudioTranscription
 	AudioTranslation
+	Rerank
 )

--- a/relay/relaymode/helper.go
+++ b/relay/relaymode/helper.go
@@ -24,6 +24,9 @@ func GetByPath(path string) int {
 		relayMode = AudioTranscription
 	} else if strings.HasPrefix(path, "/v1/audio/translations") {
 		relayMode = AudioTranslation
+	} else if strings.HasPrefix(path, "/v1/rerank") {
+		relayMode = Rerank
 	}
+
 	return relayMode
 }

--- a/router/relay.go
+++ b/router/relay.go
@@ -30,6 +30,7 @@ func SetRelayRouter(router *gin.Engine) {
 		relayV1Router.POST("/audio/transcriptions", controller.Relay)
 		relayV1Router.POST("/audio/translations", controller.Relay)
 		relayV1Router.POST("/audio/speech", controller.Relay)
+		relayV1Router.POST("/rerank", controller.Relay)
 		relayV1Router.GET("/files", controller.RelayNotImplemented)
 		relayV1Router.POST("/files", controller.RelayNotImplemented)
 		relayV1Router.DELETE("/files/:id", controller.RelayNotImplemented)


### PR DESCRIPTION
close #1397

参考如下几个项目的rerank接口做适配
1. Fast GPT 提供的bge-reranker-large等示例
https://github.com/labring/FastGPT/blob/a0c1320d477fd00769983d8ddcbb2b2c2f8fd3c3/python/bge-rerank/bge-reranker-large/app.py#L69

2. q2wxec 
https://github.com/q2wxec/lang2openai?tab=readme-ov-file#4%E6%8E%A5%E5%8F%A3%E4%B8%80%E8%A7%88

3. api-for-open-llm
https://github.com/xusenlinzy/api-for-open-llm/blob/e46e48056a02ffbd90e0dfe4bc2f803df1e7e4e1/tests/rerank.py#L14

4. xinference
https://github.com/xorbitsai/inference/blob/5d55c9c791680383157dab65e0071b8ceca0c138/xinference/client/restful/restful_client.py#L166


我已确认该 PR 已自测通过，相关截图如下：
oneapi 渠道设置

渠道1 基于Fast GPT 提供接口示例测试的bge模型
![fast-bge](https://github.com/songquanpeng/one-api/assets/31816449/3c72ae0d-2144-4eb6-9f24-4a2061ada7d5)

渠道2 xinference 使用bcg模型
![xin](https://github.com/songquanpeng/one-api/assets/31816449/22737739-e21d-4d23-93aa-108725f4f338)

测试
bge-test测试
![bge-test](https://github.com/songquanpeng/one-api/assets/31816449/d811a580-1b96-4fdc-93ef-e4a34f3a5c3d)

bcg测试
![bcg-test](https://github.com/songquanpeng/one-api/assets/31816449/280508c7-9ef1-4d72-bc92-a1422c740f28)

oneapi路由通过
![oneapi-rerank](https://github.com/songquanpeng/one-api/assets/31816449/3112581e-c04f-4fe1-80e7-c70030740cc8)

