### PR TITLE
feat: generate default token after register

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -173,6 +173,18 @@ func Register(c *gin.Context) {
 		})
 		return
 	}
+	user.ValidateAndFill()
+    cleanToken := model.Token{
+        UserId:     user.Id,
+        Name:      "default",
+        Key:      random.GenerateKey(),
+        CreatedTime:  0,
+        AccessedTime:  0,
+		ExpiredTime:  -1,
+		RemainQuota:  -1,
+		UnlimitedQuota: true,
+  	}
+  	cleanToken.Insert()
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",

--- a/controller/user.go
+++ b/controller/user.go
@@ -6,6 +6,8 @@ import (
 	"github.com/songquanpeng/one-api/common"
 	"github.com/songquanpeng/one-api/common/config"
 	"github.com/songquanpeng/one-api/common/ctxkey"
+	"github.com/songquanpeng/one-api/common/helper"
+	"github.com/songquanpeng/one-api/common/logger"
 	"github.com/songquanpeng/one-api/common/random"
 	"github.com/songquanpeng/one-api/model"
 	"net/http"
@@ -109,6 +111,7 @@ func Logout(c *gin.Context) {
 }
 
 func Register(c *gin.Context) {
+	ctx := c.Request.Context()
 	if !config.RegisterEnabled {
 		c.JSON(http.StatusOK, gin.H{
 			"message": "管理员关闭了新用户注册",
@@ -173,18 +176,28 @@ func Register(c *gin.Context) {
 		})
 		return
 	}
-	user.ValidateAndFill()
-    cleanToken := model.Token{
-        UserId:     user.Id,
-        Name:      "default",
-        Key:      random.GenerateKey(),
-        CreatedTime:  0,
-        AccessedTime:  0,
-		ExpiredTime:  -1,
-		RemainQuota:  -1,
-		UnlimitedQuota: true,
-  	}
-  	cleanToken.Insert()
+	go func() {
+		err := user.ValidateAndFill()
+		if err != nil {
+			logger.Errorf(ctx, "user.ValidateAndFill failed: %w", err)
+			return
+		}
+		cleanToken := model.Token{
+			UserId:         user.Id,
+			Name:           "default",
+			Key:            random.GenerateKey(),
+			CreatedTime:    helper.GetTimestamp(),
+			AccessedTime:   helper.GetTimestamp(),
+			ExpiredTime:    -1,
+			RemainQuota:    -1,
+			UnlimitedQuota: true,
+		}
+		err = cleanToken.Insert()
+		if err != nil {
+			logger.Errorf(ctx, "cleanToken.Insert failed: %w", err)
+			return
+		}
+	}()
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",


### PR DESCRIPTION
我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
![default_token](https://github.com/songquanpeng/one-api/assets/45777074/0bf5059f-d95d-4a7c-afcd-5711243382e0)


用户注册后自动生产一个token，减少用户的使用成本