### PR TITLE
fixed the bug of react-apexcharts version

### DIFF
--- a/web/berry/package.json
+++ b/web/berry/package.json
@@ -26,7 +26,7 @@
     "notistack": "^3.0.1",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
-    "react-apexcharts": "^1.4.0",
+    "react-apexcharts": "1.4.0",
     "react-device-detect": "^2.2.2",
     "react-dom": "^18.2.0",
     "react-perfect-scrollbar": "^1.5.8",


### PR DESCRIPTION
close #1456 

修复新版本 react-apexcharts 和 apexcharts 的版本冲突的问题，该冲突会导致在Zeabur等平台上部署失败，详情见issue

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
![image](https://github.com/songquanpeng/one-api/assets/134143178/6c0ef39b-ba79-4e0b-bd34-b319a8b1fdad)
