### PR TITLE
feat: Support gemini embeddings (text-embedding-004,embedding-001)

### DIFF
--- a/relay/adaptor/gemini/adaptor.go
+++ b/relay/adaptor/gemini/adaptor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/songquanpeng/one-api/relay/adaptor/openai"
 	"github.com/songquanpeng/one-api/relay/meta"
 	"github.com/songquanpeng/one-api/relay/model"
+	"github.com/songquanpeng/one-api/relay/relaymode"
 )
 
 type Adaptor struct {
@@ -24,7 +25,14 @@ func (a *Adaptor) Init(meta *meta.Meta) {
 
 func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
 	version := helper.AssignOrDefault(meta.Config.APIVersion, config.GeminiVersion)
-	action := "generateContent"
+	action := ""
+	switch meta.Mode {
+	case relaymode.Embeddings:
+		action = "batchEmbedContents"
+	default:
+		action = "generateContent"
+	}
+
 	if meta.IsStream {
 		action = "streamGenerateContent?alt=sse"
 	}
@@ -41,7 +49,14 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 	if request == nil {
 		return nil, errors.New("request is nil")
 	}
-	return ConvertRequest(*request), nil
+	switch relayMode {
+	case relaymode.Embeddings:
+		geminiEmbeddingRequest := ConvertEmbeddingRequest(*request)
+		return geminiEmbeddingRequest, nil
+	default:
+		geminiRequest := ConvertRequest(*request)
+		return geminiRequest, nil
+	}
 }
 
 func (a *Adaptor) ConvertImageRequest(request *model.ImageRequest) (any, error) {
@@ -61,7 +76,12 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Met
 		err, responseText = StreamHandler(c, resp)
 		usage = openai.ResponseText2Usage(responseText, meta.ActualModelName, meta.PromptTokens)
 	} else {
-		err, usage = Handler(c, resp, meta.PromptTokens, meta.ActualModelName)
+		switch meta.Mode {
+		case relaymode.Embeddings:
+			err, usage = EmbeddingHandler(c, resp)
+		default:
+			err, usage = Handler(c, resp, meta.PromptTokens, meta.ActualModelName)
+		}
 	}
 	return
 }

--- a/relay/adaptor/gemini/constants.go
+++ b/relay/adaptor/gemini/constants.go
@@ -4,5 +4,5 @@ package gemini
 
 var ModelList = []string{
 	"gemini-pro", "gemini-1.0-pro-001", "gemini-1.5-pro",
-	"gemini-pro-vision", "gemini-1.0-pro-vision-001",
+	"gemini-pro-vision", "gemini-1.0-pro-vision-001", "embedding-001", "text-embedding-004",
 }

--- a/relay/adaptor/gemini/main.go
+++ b/relay/adaptor/gemini/main.go
@@ -134,6 +134,29 @@ func ConvertRequest(textRequest model.GeneralOpenAIRequest) *ChatRequest {
 	return &geminiRequest
 }
 
+func ConvertEmbeddingRequest(request model.GeneralOpenAIRequest) *BatchEmbeddingRequest {
+	inputs := request.ParseInput()
+	requests := make([]EmbeddingRequest, len(inputs))
+	model := fmt.Sprintf("models/%s", request.Model)
+
+	for i, input := range inputs {
+		requests[i] = EmbeddingRequest{
+			Model: model,
+			Content: ChatContent{
+				Parts: []Part{
+					{
+						Text: input,
+					},
+				},
+			},
+		}
+	}
+
+	return &BatchEmbeddingRequest{
+		Requests: requests,
+	}
+}
+
 type ChatResponse struct {
 	Candidates     []ChatCandidate    `json:"candidates"`
 	PromptFeedback ChatPromptFeedback `json:"promptFeedback"`
@@ -228,6 +251,23 @@ func streamResponseGeminiChat2OpenAI(geminiResponse *ChatResponse) *openai.ChatC
 	response.Model = "gemini"
 	response.Choices = []openai.ChatCompletionsStreamResponseChoice{choice}
 	return &response
+}
+
+func embeddingResponseGemini2OpenAI(response *EmbeddingResponse) *openai.EmbeddingResponse {
+	openAIEmbeddingResponse := openai.EmbeddingResponse{
+		Object: "list",
+		Data:   make([]openai.EmbeddingResponseItem, 0, len(response.Embeddings)),
+		Model:  "gemini-embedding",
+		Usage:  model.Usage{TotalTokens: 0},
+	}
+	for _, item := range response.Embeddings {
+		openAIEmbeddingResponse.Data = append(openAIEmbeddingResponse.Data, openai.EmbeddingResponseItem{
+			Object:    `embedding`,
+			Index:     0,
+			Embedding: item.Values,
+		})
+	}
+	return &openAIEmbeddingResponse
 }
 
 func StreamHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusCode, string) {
@@ -336,4 +376,40 @@ func Handler(c *gin.Context, resp *http.Response, promptTokens int, modelName st
 	c.Writer.WriteHeader(resp.StatusCode)
 	_, err = c.Writer.Write(jsonResponse)
 	return nil, &usage
+}
+
+func EmbeddingHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusCode, *model.Usage) {
+	var geminiEmbeddingResponse EmbeddingResponse
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return openai.ErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError), nil
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return openai.ErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), nil
+	}
+	err = json.Unmarshal(responseBody, &geminiEmbeddingResponse)
+	if err != nil {
+		return openai.ErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+	if geminiEmbeddingResponse.Error != nil {
+		return &model.ErrorWithStatusCode{
+			Error: model.Error{
+				Message: geminiEmbeddingResponse.Error.Message,
+				Type:    "gemini_error",
+				Param:   "",
+				Code:    geminiEmbeddingResponse.Error.Code,
+			},
+			StatusCode: resp.StatusCode,
+		}, nil
+	}
+	fullTextResponse := embeddingResponseGemini2OpenAI(&geminiEmbeddingResponse)
+	jsonResponse, err := json.Marshal(fullTextResponse)
+	if err != nil {
+		return openai.ErrorWrapper(err, "marshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(resp.StatusCode)
+	_, err = c.Writer.Write(jsonResponse)
+	return nil, &fullTextResponse.Usage
 }

--- a/relay/adaptor/gemini/model.go
+++ b/relay/adaptor/gemini/model.go
@@ -7,6 +7,33 @@ type ChatRequest struct {
 	Tools            []ChatTools          `json:"tools,omitempty"`
 }
 
+type EmbeddingRequest struct {
+	Model                string      `json:"model"`
+	Content              ChatContent `json:"content"`
+	TaskType             string      `json:"taskType,omitempty"`
+	Title                string      `json:"title,omitempty"`
+	OutputDimensionality int         `json:"outputDimensionality,omitempty"`
+}
+
+type BatchEmbeddingRequest struct {
+	Requests []EmbeddingRequest `json:"requests"`
+}
+
+type EmbeddingData struct {
+	Values []float64 `json:"values"`
+}
+
+type EmbeddingResponse struct {
+	Embeddings []EmbeddingData `json:"embeddings"`
+	Error      *Error          `json:"error,omitempty"`
+}
+
+type Error struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+	Status  string `json:"status,omitempty"`
+}
+
 type InlineData struct {
 	MimeType string `json:"mimeType"`
 	Data     string `json:"data"`


### PR DESCRIPTION
close #1313
close #868

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）

```
[SYS] 2024/05/28 - 14:34:52 | One API v0.0.0 started 
[SYS] 2024/05/28 - 14:34:52 | using MySQL as database 
[SYS] 2024/05/28 - 14:34:52 | database migration started 
[SYS] 2024/05/28 - 14:34:52 | database migrated 
[SYS] 2024/05/28 - 14:34:52 | REDIS_CONN_STRING not set, Redis is not enabled 
[SYS] 2024/05/28 - 14:34:52 | using theme berry 
[SYS] 2024/05/28 - 14:34:52 | initializing token encoders 
[SYS] 2024/05/28 - 14:34:57 | token encoders initialized 
[SYS] 2024/05/28 - 14:35:50 | model ratio not found: text-embedding-004 
[INFO] 2024/05/28 - 14:35:50 | 202405281435508260323702375031 | user 1 has enough quota 499999972164332, trusted and no need to pre-consume 
[GIN] 2024/05/28 - 14:35:50 | 202405281435508260323702375031 | 200 |  426.223764ms | ip |    POST /v1/embeddings
[INFO] 2024/05/28 - 14:35:50 | 202405281435508260323702375031 | record consume log: userId=1, channelId=4, promptTokens=0, completionTokens=0, modelName=text-embedding-004, tokenName=FastChat, quota=0, content=模型倍率 30.00，分组倍率 1.00，补全倍率 1.00 
[SYS] 2024/05/28 - 14:36:07 | model ratio not found: text-embedding-004 
[INFO] 2024/05/28 - 14:36:07 | 2024052814360737548440985902243 | user 1 has enough quota 499999972164332, trusted and no need to pre-consume 
[GIN] 2024/05/28 - 14:36:07 | 2024052814360737548440985902243 | 200 |  353.767544ms | ip |    POST /v1/embeddings
[INFO] 2024/05/28 - 14:36:07 | 2024052814360737548440985902243 | record consume log: userId=1, channelId=4, promptTokens=0, completionTokens=0, modelName=text-embedding-004, tokenName=FastChat, quota=0, content=模型倍率 30.00，分组倍率 1.00，补全倍率 1.00
```

模型名字在测试时有映射（google-text-embedding-004->text-embedding-004）
**多条：**
![image](https://github.com/songquanpeng/one-api/assets/18144577/f7809f3e-10ae-4030-b805-596e570c0811)
**单条：**
![image](https://github.com/songquanpeng/one-api/assets/18144577/02bb1dda-2a5a-43e8-97f1-b03a0ae28e5a)
