### PR TITLE
fix: Gemini streaming return being truncated by FinishReason.

### DIFF
--- a/relay/adaptor/gemini/main.go
+++ b/relay/adaptor/gemini/main.go
@@ -222,8 +222,10 @@ func responseGeminiChat2OpenAI(response *ChatResponse) *openai.TextResponse {
 func streamResponseGeminiChat2OpenAI(geminiResponse *ChatResponse) *openai.ChatCompletionsStreamResponse {
 	var choice openai.ChatCompletionsStreamResponseChoice
 	choice.Delta.Content = geminiResponse.GetResponseText()
-	choice.FinishReason = &constant.StopFinishReason
+	//choice.FinishReason = &constant.StopFinishReason
 	var response openai.ChatCompletionsStreamResponse
+	response.Id = fmt.Sprintf("chatcmpl-%s", random.GetUUID())
+	response.Created = helper.GetTimestamp()
 	response.Object = "chat.completion.chunk"
 	response.Model = "gemini"
 	response.Choices = []openai.ChatCompletionsStreamResponseChoice{choice}


### PR DESCRIPTION
close #1408
close #1386

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）

___

理论上早期的版本应该没有返回FinishReason？所以流不会被截断。
但是在v0.6.7左右的版本修复stream流问题时这部分被修正了#1382，引入了FinishReason字段。涉及问题#1345、
#1328。
但是有个比较尴尬的地方在于，实际上Gemini的API本身就在每个流message中返回STOP（看起来跟早期的Gemini的表现不太一致，不知道为什么会出现这个问题）。
![image](https://github.com/songquanpeng/one-api/assets/18144577/6ae064dc-b299-48a2-a834-cc69baa4cc3a)
<img width="952" alt="1716881148212" src="https://github.com/songquanpeng/one-api/assets/18144577/f073a74e-c7b1-4719-9c3f-64b7654b3abb">

**因为是流式返回，没法准确预知哪个是最后一条message，只能暂时去掉FinishReason字段了。**

___

启动：
```
[SYS] 2024/05/28 - 15:26:32 | One API v0.0.0 started 
[SYS] 2024/05/28 - 15:26:32 | running in debug mode 
[SYS] 2024/05/28 - 15:26:32 | SQL_DSN not set, using SQLite as database 
[SYS] 2024/05/28 - 15:26:32 | database migration started 
[SYS] 2024/05/28 - 15:26:32 | database migrated 
[SYS] 2024/05/28 - 15:26:32 | REDIS_CONN_STRING not set, Redis is not enabled 
[SYS] 2024/05/28 - 15:26:32 | using theme default 
[SYS] 2024/05/28 - 15:26:32 | initializing token encoders 
[SYS] 2024/05/28 - 15:26:33 | token encoders initialized 
[DEBUG] 2024/05/28 - 15:27:06 | 2024052815270615146503779860442 | request body: {
    "model": "gemini-pro",
    "temperature": 0,
    "messages": [
        {
            "role": "user",
            "content": "Why sky is blue?"
        }
    ],
    "stream": true
} 
[SYS] 2024/05/28 - 15:27:06 | failed to get token encoder for model gemini-pro: no encoding for model gemini-pro, using encoder for gpt-3.5-turbo 
[INFO] 2024/05/28 - 15:27:06 | 2024052815270615146503779860442 | user 1 has enough quota 499999999963990, trusted and no need to pre-consume 
[DEBUG] 2024/05/28 - 15:27:06 | 2024052815270615146503779860442 | converted request: 
{"contents":[{"role":"user","parts":[{"text":"Why sky is blue?"}]}],"safety_settings":[{"category":"HARM_CATEGORY_HARASSMENT","threshold":"BLOCK_NONE"},{"category":"HARM_CATEGORY_HATE_SPEECH","threshold":"BLOCK_NONE"},{"category":"HARM_CATEGORY_SEXUALLY_EXPLICIT","threshold":"BLOCK_NONE"},{"category":"HARM_CATEGORY_DANGEROUS_CONTENT","threshold":"BLOCK_NONE"}],"generation_config":{}} 
[GIN] 2024/05/28 - 15:27:12 | 2024052815270615146503779860442 | 200 |  6.303667817s |       127.0.0.1 |    POST /v1/chat/completions
[INFO] 2024/05/28 - 15:27:12 | 2024052815270615146503779860442 | record consume log: userId=1, channelId=1, promptTokens=12, completionTokens=337, modelName=gemini-pro, tokenName=Test, quota=1023, content=模型倍率 1.00，分组倍率 1.00，补全倍率 3.00 
```
