### PR TITLE
fix: fix sparkdesk function call

### DIFF
--- a/relay/adaptor/xunfei/main.go
+++ b/relay/adaptor/xunfei/main.go
@@ -45,8 +45,12 @@ func requestOpenAI2Xunfei(request model.GeneralOpenAIRequest, xunfeiAppId string
 	xunfeiRequest.Payload.Message.Text = messages
 
 	if strings.HasPrefix(domain, "generalv3") {
+		functions := make([]model.Function, len(request.Tools))
+		for i, tool := range request.Tools {
+			functions[i] = tool.Function
+		}
 		xunfeiRequest.Payload.Functions = &Functions{
-			Text: request.Tools,
+			Text: functions,
 		}
 	}
 

--- a/relay/adaptor/xunfei/model.go
+++ b/relay/adaptor/xunfei/model.go
@@ -10,7 +10,7 @@ type Message struct {
 }
 
 type Functions struct {
-	Text []model.Tool `json:"text,omitempty"`
+	Text []model.Function `json:"text,omitempty"`
 }
 
 type ChatRequest struct {


### PR DESCRIPTION
修复了讯飞星火的函数调用功能。
调用Spark Pro/Max 的 Function call ，只会返回普通对话形式的回答，而不是 function call格式的的回答。
原因是在请求体中多包了一层json，导致星火不能正确解析请求体中的 function call 的相关参数。
现在修正了请求体的格式，能够按预期回答。

close #1543 #1524 #1493 #1457

我已确认该 PR 已自测通过，以 openai 标准格式的同一个 req 调用星火，智谱和openai 的 function call 类型对话，均能正常返回function call格式的相同的 resp。相关截图如下：

<img width="819" alt="image" src="https://github.com/songquanpeng/one-api/assets/40982122/d4580ace-441d-47a5-ac1c-1d322a135dd0">
<img width="907" alt="image" src="https://github.com/songquanpeng/one-api/assets/40982122/bfc84832-5323-4b02-8354-fda1a302d986">
<img width="836" alt="image" src="https://github.com/songquanpeng/one-api/assets/40982122/6b5e25df-2021-4b66-bba7-dbb75da90c98">



[//]: # (请按照以下格式关联 issue)
[//]: # (请在提交 PR 前确认所提交的功能可用，需要附上截图，谢谢)
[//]: # (项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解)
[//]: # (开发者交流群：910657413)
[//]: # (请在提交 PR 之前删除上面的注释)

