### PR TITLE
feat: allow baseUrl for one-api

### DIFF
--- a/common/embed-file-system.go
+++ b/common/embed-file-system.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gin-contrib/static"
 	"io/fs"
 	"net/http"
+	"strings"
 )
 
 // Credit: https://github.com/gin-contrib/static/issues/19
@@ -14,7 +15,8 @@ type embedFileSystem struct {
 }
 
 func (e embedFileSystem) Exists(prefix string, path string) bool {
-	_, err := e.Open(path)
+	relPath := strings.TrimPrefix(path, prefix)
+	_, err := e.Open(relPath)
 	return err == nil
 }
 

--- a/router/api.go
+++ b/router/api.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetApiRouter(router *gin.Engine) {
+func SetApiRouter(router *gin.RouterGroup) {
 	apiRouter := router.Group("/api")
 	apiRouter.Use(gzip.Gzip(gzip.DefaultCompression))
 	apiRouter.Use(middleware.GlobalAPIRateLimit())

--- a/router/dashboard.go
+++ b/router/dashboard.go
@@ -7,7 +7,7 @@ import (
 	"github.com/songquanpeng/one-api/middleware"
 )
 
-func SetDashboardRouter(router *gin.Engine) {
+func SetDashboardRouter(router *gin.RouterGroup) {
 	apiRouter := router.Group("/")
 	apiRouter.Use(middleware.CORS())
 	apiRouter.Use(gzip.Gzip(gzip.DefaultCompression))

--- a/router/main.go
+++ b/router/main.go
@@ -11,7 +11,13 @@ import (
 	"strings"
 )
 
-func SetRouter(router *gin.Engine, buildFS embed.FS) {
+func SetRouter(engine *gin.Engine, buildFS embed.FS) {
+	var baseUrl = os.Getenv("BASE_URL")
+	if baseUrl == "" {
+		baseUrl = "/"
+	}
+	router := engine.Group(baseUrl)
+
 	SetApiRouter(router)
 	SetDashboardRouter(router)
 	SetRelayRouter(router)
@@ -21,10 +27,10 @@ func SetRouter(router *gin.Engine, buildFS embed.FS) {
 		logger.SysLog("FRONTEND_BASE_URL is ignored on master node")
 	}
 	if frontendBaseUrl == "" {
-		SetWebRouter(router, buildFS)
+		SetWebRouter(engine, baseUrl, buildFS)
 	} else {
 		frontendBaseUrl = strings.TrimSuffix(frontendBaseUrl, "/")
-		router.NoRoute(func(c *gin.Context) {
+		engine.NoRoute(func(c *gin.Context) {
 			c.Redirect(http.StatusMovedPermanently, fmt.Sprintf("%s%s", frontendBaseUrl, c.Request.RequestURI))
 		})
 	}

--- a/router/relay.go
+++ b/router/relay.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetRelayRouter(router *gin.Engine) {
+func SetRelayRouter(router *gin.RouterGroup) {
 	router.Use(middleware.CORS())
 	// https://platform.openai.com/docs/api-reference/introduction
 	modelsRouter := router.Group("/v1/models")

--- a/router/web.go
+++ b/router/web.go
@@ -14,13 +14,15 @@ import (
 	"strings"
 )
 
-func SetWebRouter(router *gin.Engine, buildFS embed.FS) {
-	indexPageData, _ := buildFS.ReadFile(fmt.Sprintf("web/build/%s/index.html", config.Theme))
-	router.Use(gzip.Gzip(gzip.DefaultCompression))
-	router.Use(middleware.GlobalWebRateLimit())
-	router.Use(middleware.Cache())
-	router.Use(static.Serve("/", common.EmbedFolder(buildFS, fmt.Sprintf("web/build/%s", config.Theme))))
-	router.NoRoute(func(c *gin.Context) {
+func SetWebRouter(engine *gin.Engine, baseUrl string, buildFS embed.FS) {
+	basePath := fmt.Sprintf("web/build/%s", config.Theme)
+	indexPageData, _ := buildFS.ReadFile(fmt.Sprintf("%s/index.html", basePath))
+	engine.Use(gzip.Gzip(gzip.DefaultCompression))
+	engine.Use(middleware.GlobalWebRateLimit())
+	engine.Use(middleware.Cache())
+	engine.Use(static.Serve(baseUrl, common.EmbedFolder(buildFS, basePath)))
+
+	engine.NoRoute(func(c *gin.Context) {
 		if strings.HasPrefix(c.Request.RequestURI, "/v1") || strings.HasPrefix(c.Request.RequestURI, "/api") {
 			controller.RelayNotFound(c)
 			return

--- a/web/build.sh
+++ b/web/build.sh
@@ -8,6 +8,7 @@ while IFS= read -r theme; do
     rm -r build/$theme
     cd "$theme"
     npm install
+    jq ".homepage=\"${REACT_APP_BASE_URL}\"" package.json > tmp.json && mv tmp.json package.json ;
     DISABLE_ESLINT_PLUGIN='true' REACT_APP_VERSION=$version npm run build
     cd ..
 done < THEMES

--- a/web/default/package.json
+++ b/web/default/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-template",
   "version": "0.1.0",
+  "homepage": "",
   "private": true,
   "dependencies": {
     "axios": "^0.27.2",

--- a/web/default/public/index.html
+++ b/web/default/public/index.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="logo.png" />
+    <link id="favicon" rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#ffffff" />
     <meta

--- a/web/default/src/components/Header.js
+++ b/web/default/src/components/Header.js
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { UserContext } from '../context/User';
-
+import { BASE_URL } from "../config";
 import { Button, Container, Dropdown, Icon, Menu, Segment } from 'semantic-ui-react';
 import { API, getLogo, getSystemName, isAdmin, isMobile, showSuccess } from '../helpers';
 import '../index.css';
@@ -119,19 +119,14 @@ const Header = () => {
           size='large'
           style={
             showSidebar
-              ? {
-                borderBottom: 'none',
-                marginBottom: '0',
-                borderTop: 'none',
-                height: '51px'
-              }
+              ? { borderBottom: 'none', marginBottom: '0', borderTop: 'none', height: '51px' }
               : { borderTop: 'none', height: '52px' }
           }
         >
           <Container>
             <Menu.Item as={Link} to='/'>
               <img
-                src={logo}
+                src={ BASE_URL + logo}
                 alt='logo'
                 style={{ marginRight: '0.75em' }}
               />
@@ -188,7 +183,7 @@ const Header = () => {
       <Menu borderless style={{ borderTop: 'none' }}>
         <Container>
           <Menu.Item as={Link} to='/' className={'hide-on-mobile'}>
-            <img src={logo} alt='logo' style={{ marginRight: '0.75em' }} />
+            <img src={ BASE_URL + logo} alt='logo' style={{ marginRight: '0.75em' }} />
             <div style={{ fontSize: '20px' }}>
               <b>{systemName}</b>
             </div>

--- a/web/default/src/components/LoginForm.js
+++ b/web/default/src/components/LoginForm.js
@@ -4,6 +4,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { UserContext } from '../context/User';
 import { API, getLogo, showError, showSuccess, showWarning } from '../helpers';
 import { onGitHubOAuthClicked, onLarkOAuthClicked } from './utils';
+import { BASE_URL } from '../config';
 import larkIcon from '../images/lark.svg';
 
 const LoginForm = () => {
@@ -87,7 +88,7 @@ const LoginForm = () => {
     <Grid textAlign='center' style={{ marginTop: '48px' }}>
       <Grid.Column style={{ maxWidth: 450 }}>
         <Header as='h2' color='' textAlign='center'>
-          <Image src={logo} /> 用户登录
+          <Image src={ BASE_URL + logo} /> 用户登录
         </Header>
         <Form size='large'>
           <Segment>
@@ -151,13 +152,13 @@ const LoginForm = () => {
               )}
               {status.lark_client_id ? (
                 <div style={{
-                  background: "radial-gradient(circle, #FFFFFF, #FFFFFF, #00D6B9, #2F73FF, #0a3A9C)",
-                  width: "36px",
-                  height: "36px",
-                  borderRadius: "10em",
-                  display: "flex",
-                  cursor: "pointer"
-                }}
+                    background: "radial-gradient(circle, #FFFFFF, #FFFFFF, #00D6B9, #2F73FF, #0a3A9C)",
+                    width: "36px",
+                    height: "36px",
+                    borderRadius: "10em",
+                    display: "flex",
+                    cursor: "pointer"
+                  }}
                   onClick={() => onLarkOAuthClicked(status.lark_client_id)}
                 >
                   <Image

--- a/web/default/src/components/PasswordResetConfirm.js
+++ b/web/default/src/components/PasswordResetConfirm.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Button, Form, Grid, Header, Image, Segment } from 'semantic-ui-react';
 import { API, copy, showError, showInfo, showNotice, showSuccess } from '../helpers';
+import { BASE_URL } from '../config';
 import { useSearchParams } from 'react-router-dom';
 
 const PasswordResetConfirm = () => {
@@ -37,7 +38,7 @@ const PasswordResetConfirm = () => {
       setDisableButton(false);
       setCountdown(30);
     }
-    return () => clearInterval(countdownInterval); 
+    return () => clearInterval(countdownInterval);
   }, [disableButton, countdown]);
 
   async function handleSubmit(e) {
@@ -59,12 +60,12 @@ const PasswordResetConfirm = () => {
     }
     setLoading(false);
   }
-  
+
   return (
     <Grid textAlign='center' style={{ marginTop: '48px' }}>
       <Grid.Column style={{ maxWidth: 450 }}>
         <Header as='h2' color='' textAlign='center'>
-          <Image src='/logo.png' /> 密码重置确认
+          <Image src={ BASE_URL + '/logo.png'} /> 密码重置确认
         </Header>
         <Form size='large'>
           <Segment>
@@ -79,19 +80,19 @@ const PasswordResetConfirm = () => {
             />
             {newPassword && (
               <Form.Input
-              fluid
-              icon='lock'
-              iconPosition='left'
-              placeholder='新密码'
-              name='newPassword'
-              value={newPassword}
-              readOnly
-              onClick={(e) => {
-                e.target.select();
-                navigator.clipboard.writeText(newPassword);
-                showNotice(`密码已复制到剪贴板：${newPassword}`);
-              }}
-            />            
+                fluid
+                icon='lock'
+                iconPosition='left'
+                placeholder='新密码'
+                name='newPassword'
+                value={newPassword}
+                readOnly
+                onClick={(e) => {
+                  e.target.select();
+                  navigator.clipboard.writeText(newPassword);
+                  showNotice(`密码已复制到剪贴板：${newPassword}`);
+                }}
+              />
             )}
             <Button
               color='green'
@@ -107,7 +108,7 @@ const PasswordResetConfirm = () => {
         </Form>
       </Grid.Column>
     </Grid>
-  );  
+  );
 };
 
 export default PasswordResetConfirm;

--- a/web/default/src/components/PasswordResetForm.js
+++ b/web/default/src/components/PasswordResetForm.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Button, Form, Grid, Header, Image, Segment } from 'semantic-ui-react';
 import { API, showError, showInfo, showSuccess } from '../helpers';
+import { BASE_URL } from '../config';
 import Turnstile from 'react-turnstile';
 
 const PasswordResetForm = () => {
@@ -70,7 +71,7 @@ const PasswordResetForm = () => {
     <Grid textAlign='center' style={{ marginTop: '48px' }}>
       <Grid.Column style={{ maxWidth: 450 }}>
         <Header as='h2' color='' textAlign='center'>
-          <Image src='/logo.png' /> 密码重置
+          <Image src={ BASE_URL + '/logo.png'} /> 密码重置
         </Header>
         <Form size='large'>
           <Segment>

--- a/web/default/src/components/RegisterForm.js
+++ b/web/default/src/components/RegisterForm.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Button, Form, Grid, Header, Image, Message, Segment } from 'semantic-ui-react';
 import { Link, useNavigate } from 'react-router-dom';
 import { API, getLogo, showError, showInfo, showSuccess } from '../helpers';
+import { BASE_URL } from '../config';
 import Turnstile from 'react-turnstile';
 
 const RegisterForm = () => {
@@ -101,7 +102,7 @@ const RegisterForm = () => {
     <Grid textAlign='center' style={{ marginTop: '48px' }}>
       <Grid.Column style={{ maxWidth: 450 }}>
         <Header as='h2' color='' textAlign='center'>
-          <Image src={logo} /> 新用户注册
+          <Image src={ BASE_URL + logo} /> 新用户注册
         </Header>
         <Form size='large'>
           <Segment>

--- a/web/default/src/config.js
+++ b/web/default/src/config.js
@@ -1,0 +1,1 @@
+export const BASE_URL = process.env.REACT_APP_BASE_URL || '';

--- a/web/default/src/helpers/api.js
+++ b/web/default/src/helpers/api.js
@@ -1,8 +1,11 @@
 import { showError } from './utils';
+import { BASE_URL } from '../config';
 import axios from 'axios';
 
 export const API = axios.create({
-  baseURL: process.env.REACT_APP_SERVER ? process.env.REACT_APP_SERVER : '',
+  baseURL:
+    (process.env.REACT_APP_SERVER ? process.env.REACT_APP_SERVER : '') +
+    BASE_URL,
 });
 
 API.interceptors.response.use(

--- a/web/default/src/index.js
+++ b/web/default/src/index.js
@@ -11,13 +11,14 @@ import { UserProvider } from './context/User';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { StatusProvider } from './context/Status';
+import { BASE_URL } from './config';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <StatusProvider>
       <UserProvider>
-        <BrowserRouter>
+        <BrowserRouter basename={BASE_URL}>
           <Header />
           <Container className={'main-content'}>
             <App />


### PR DESCRIPTION
## What:
允许通过系统环境变量为one-api的服务URL加上前缀，下面的例子将允许把原来的`/api/status`路径变更至`/one-api/api/status`：
```shell
BASE_URL="/one-api" PORT=3000 one-api
```
如果不设置BASE_URL则默认为空，保持原有的URL pattern。

与之相对应，如果前端进行构建，则进行两处修改：
- REACT_APP_BASE_URL="/one-api"
- package.json中的homepage字段改为"/one-api"  (可以使用下面的命令进行：`jq ".homepage=\"${REACT_APP_BASE_URL}\"" package.json > tmp.json && mv tmp.json package.json`)

## Why
一些模块中需要对one-api中进行集成，希望在同一个domain下的不同URL prefix下用nginx或其他网关反向代理不同的应用。
应用允许加上baseUrl的话会对反向代理的配置更加简单，包括前端部分。

## Validation
我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/songquanpeng/one-api/assets/1597350/147d5368-e51c-4c60-9a4f-e80c487ee8db)
