### PR TITLE
feat: add support for Claude 3 tool use (function calling)

### DIFF
--- a/relay/adaptor/anthropic/model.go
+++ b/relay/adaptor/anthropic/model.go
@@ -16,11 +16,29 @@ type Content struct {
 	Type   string       `json:"type"`
 	Text   string       `json:"text,omitempty"`
 	Source *ImageSource `json:"source,omitempty"`
+	// tool_calls
+	Id        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Input     any    `json:"input,omitempty"`
+	Content   string `json:"content,omitempty"`
+	ToolUseId string `json:"tool_use_id,omitempty"`
 }
 
 type Message struct {
 	Role    string    `json:"role"`
 	Content []Content `json:"content"`
+}
+
+type Tool struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description,omitempty"`
+	InputSchema InputSchema `json:"input_schema"`
+}
+
+type InputSchema struct {
+	Type       string `json:"type"`
+	Properties any    `json:"properties,omitempty"`
+	Required   any    `json:"required,omitempty"`
 }
 
 type Request struct {
@@ -33,6 +51,8 @@ type Request struct {
 	Temperature   float64   `json:"temperature,omitempty"`
 	TopP          float64   `json:"top_p,omitempty"`
 	TopK          int       `json:"top_k,omitempty"`
+	Tools         []Tool    `json:"tools,omitempty"`
+	ToolChoice    any       `json:"tool_choice,omitempty"`
 	//Metadata    `json:"metadata,omitempty"`
 }
 
@@ -61,6 +81,7 @@ type Response struct {
 type Delta struct {
 	Type         string  `json:"type"`
 	Text         string  `json:"text"`
+	PartialJson  string  `json:"partial_json,omitempty"`
 	StopReason   *string `json:"stop_reason"`
 	StopSequence *string `json:"stop_sequence"`
 }

--- a/relay/adaptor/aws/main.go
+++ b/relay/adaptor/aws/main.go
@@ -163,8 +163,10 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 			if meta != nil {
 				usage.PromptTokens += meta.Usage.InputTokens
 				usage.CompletionTokens += meta.Usage.OutputTokens
-				id = fmt.Sprintf("chatcmpl-%s", meta.Id)
-				return true
+				if len(meta.Id) > 0 { // only message_start has id. else it's finish_reason
+					id = fmt.Sprintf("chatcmpl-%s", meta.Id)
+					return true
+				}
 			}
 			if response == nil {
 				return true

--- a/relay/adaptor/aws/model.go
+++ b/relay/adaptor/aws/model.go
@@ -9,9 +9,12 @@ type Request struct {
 	// AnthropicVersion should be "bedrock-2023-05-31"
 	AnthropicVersion string              `json:"anthropic_version"`
 	Messages         []anthropic.Message `json:"messages"`
+	System           string              `json:"system,omitempty"`
 	MaxTokens        int                 `json:"max_tokens,omitempty"`
 	Temperature      float64             `json:"temperature,omitempty"`
 	TopP             float64             `json:"top_p,omitempty"`
 	TopK             int                 `json:"top_k,omitempty"`
 	StopSequences    []string            `json:"stop_sequences,omitempty"`
+	Tools            []anthropic.Tool    `json:"tools,omitempty"`
+	ToolChoice       any                 `json:"tool_choice,omitempty"`
 }

--- a/relay/model/message.go
+++ b/relay/model/message.go
@@ -1,10 +1,11 @@
 package model
 
 type Message struct {
-	Role      string  `json:"role,omitempty"`
-	Content   any     `json:"content,omitempty"`
-	Name      *string `json:"name,omitempty"`
-	ToolCalls []Tool  `json:"tool_calls,omitempty"`
+	Role       string  `json:"role,omitempty"`
+	Content    any     `json:"content,omitempty"`
+	Name       *string `json:"name,omitempty"`
+	ToolCalls  []Tool  `json:"tool_calls,omitempty"`
+	ToolCallId string  `json:"tool_call_id,omitempty"`
 }
 
 func (m Message) IsStringContent() bool {

--- a/relay/model/tool.go
+++ b/relay/model/tool.go
@@ -2,13 +2,13 @@ package model
 
 type Tool struct {
 	Id       string   `json:"id,omitempty"`
-	Type     string   `json:"type"`
+	Type     string   `json:"type,omitempty"` // when splicing claude tools stream messages, it is empty
 	Function Function `json:"function"`
 }
 
 type Function struct {
 	Description string `json:"description,omitempty"`
-	Name        string `json:"name"`
+	Name        string `json:"name,omitempty"`       // when splicing claude tools stream messages, it is empty
 	Parameters  any    `json:"parameters,omitempty"` // request
 	Arguments   any    `json:"arguments,omitempty"`  // response
 }


### PR DESCRIPTION
close #1572 #1258 #1504 #1299 #1374 #1520  (claude)

我已确认该 PR 已自测通过，相关截图如下：

<img width="1474" alt="20240701151736" src="https://github.com/songquanpeng/one-api/assets/18101258/08560632-d340-4637-adfc-9f3e50b606c2">

## 分叉情况

在流式消息下存在一些与 OpenAI 分叉的情况

为了便于理解这些差异，以下引用了来自 Claude 官方文档中的流式工具使用响应示例：https://docs.anthropic.com/en/api/messages-streaming#streaming-request-with-tool-use

```
event: message_start
data: {"type":"message_start","message":{"id":"msg_014p7gG3wDgGV9EUtLvnow3U","type":"message","role":"assistant","model":"claude-3-haiku-20240307","stop_sequence":null,"usage":{"input_tokens":472,"output_tokens":2},"content":[],"stop_reason":null}}

event: content_block_start
data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}

event: ping
data: {"type": "ping"}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Okay"}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":","}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" let"}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"'s"}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" check"}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" the"}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" weather"}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" for"}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" San"}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Francisco"}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":","}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" CA"}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":"}}

event: content_block_stop
data: {"type":"content_block_stop","index":0}

event: content_block_start
data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01T1x1fJ34qAmk2tNTrN7Up6","name":"get_weather","input":{}}}

event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}}

event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"location\":"}}

event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":" \"San"}}

event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":" Francisc"}}

event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"o,"}}

event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":" CA\""}}

event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":", "}}

event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"unit\": \"fah"}}

event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"renheit\"}"}}

event: content_block_stop
data: {"type":"content_block_stop","index":1}

event: message_delta
data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":89}}

event: message_stop
data: {"type":"message_stop"}
```

### Arguments 为空

**Claude Request Body:**

```json
{
    "model": "claude-3-5-sonnet-20240620",
    "messages": [
        {
            "role": "user",
            "content": [
                {
                    "type": "text",
                    "text": "现在几点了"
                }
            ]
        }
    ],
    "max_tokens": 4096,
    "stream": true,
    "tools": [
        {
            "name": "getCurrentTime",
            "description": "获取当前时间",
            "input_schema": {
                "type": "object",
                "properties": {}
            }
        }
    ],
    "tool_choice": {
        "type": "auto"
    }
}
```

**Claude Response:**

![Screenshot 2024-07-01 153825](https://github.com/songquanpeng/one-api/assets/18101258/f7ad2a50-0e85-431b-b03f-33731274d74f)

**OpenAI Request Body:**

```json
{
    "model": "gpt-4o",
    "stream": true,
    "messages": [
        {
            "content": "现在几点了",
            "role": "user"
        }
    ],
    "tools": [
        {
            "function": {
                "description": "获取当前时间",
                "name": "getCurrentTime",
                "parameters": {
                    "type": "object",
                    "properties": {}
                }
            },
            "type": "function"
        }
    ]
}
```

**OpenAI Response:**

![Screenshot 2024-07-01 154322](https://github.com/songquanpeng/one-api/assets/18101258/aef3c4c2-dcbe-41f8-957c-48f65d3dc07c)

在 OpenAI 流式函数调用 **没有 arguments** 的情况下，会响应一个 `{}`，在 Claude 流式中则 **什么都不响应**  (经过请求测试 `content_block_delta` 第一个 `partial_json` **始终为 `""`**，`content_block_start` `tool_use` 的 `input` **始终为 `{}`** )

commit [d16cd615](https://github.com/songquanpeng/one-api/tree/d16cd6152ef22b99fc6003fd61147de74b280311) 针对这一情况，当 `finish_reason` 时，且 `arguments` 为空的情况下，添加一个 `{}` 以便更好地与 OpenAI 的行为保持一致，兼容一些应用 (如 LobeChat，若不添加 `{}` 则无法调用时钟时间)

### 多余的响应

Claude 在流式响应中包含了 `ping`, `content_block_stop`, `message_stop` 等事件，这可能导致流式传输中出现额外输出。尽管在 LobeChat 的测试中，这些多余的输出并未对函数调用的使用造成影响，但仍可以  **由社区讨论确定是否有必要通过过滤逻辑来去除这些额外响应，尤其是当它们开始干扰某些应用功能使用时**

![Screenshot 2024-07-01 160418](https://github.com/songquanpeng/one-api/assets/18101258/910f39a5-3bf1-4bd9-b908-08c12324c5ca)

## 已知的问题

在进行请求转换 (`ConvertRequest`) 时，Claude 的 `role` 枚举仅能包含 `user`, `assistant` refer: https://docs.anthropic.com/en/api/messages

然而 OpenAI 使用 **role** `tool` 传递函数调用的结果给模型 refer: https://platform.openai.com/docs/guides/function-calling

Claude 通过 `user` 来传递 `tool_result` refer: https://docs.anthropic.com/en/docs/build-with-claude/tool-use#handling-tool-use-and-tool-result-content-blocks

同时 Claude 中 **role 需要交替组合**，以 LobeChat 的时钟时间调用为例

**Request Body:**

```json
{
    "model": "claude-3-5-sonnet-20240620",
    "stream": true,
    "frequency_penalty": 0,
    "presence_penalty": 0,
    "temperature": 0.6,
    "top_p": 1,
    "messages": [
        {
            "content": "## Tools\n\nYou can use these tools below:\n\n### Clock Time\n\nDisplay a clock to show current time\n\nThe APIs you can use:\n\n#### clock-time____getCurrentTime____standalone\n\n获取当前时间\n\n### Realtime Weather\n\nGet realtime weather information\n\nThe APIs you can use:\n\n#### realtime-weather____fetchCurrentWeather\n\n获取当前天气情况",
            "role": "system"
        },
        {
            "content": "现在几点了",
            "role": "user"
        },
        {
            "content": "为了回答您的问题,我需要使用时钟工具来获取当前的准确时间。让我为您查询一下。",
            "role": "assistant",
            "tool_calls": [
                {
                    "function": {
                        "arguments": "{}",
                        "name": "clock-time____getCurrentTime____standalone"
                    },
                    "id": "toolu_01MTZCkPPSgR9927FddGHgkz",
                    "type": "function"
                }
            ]
        },
        {
            "content": "...",
            "name": "clock-time____getCurrentTime____standalone",
            "role": "tool",
            "tool_call_id": "toolu_01MTZCkPPSgR9927FddGHgkz"
        },
        {
            "content": "你好",
            "role": "user"
        }
    ],
    "tools": [
        {
            "function": {
                "description": "获取当前时间",
                "name": "clock-time____getCurrentTime____standalone",
                "parameters": {
                    "type": "object",
                    "properties": {}
                }
            },
            "type": "function"
        }
    ]
}
```

在 convert 后，`tool` 会被替换为 `user`

```json
{
    ....
        {
            "role": "user",
            "content": [
                {
                    "type": "tool_result",
                    "content": "...",
                    "tool_use_id": "toolu_01MTZCkPPSgR9927FddGHgkz"
                }
            ]
        },
    ....
}
```

此时出现了连续多个 `role` 为 `user` 的情况，报错

```json
{"type":"error","error":{"type":"invalid_request_error","message":"messages: roles must alternate between \"user\" and \"assistant\", but found multiple \"user\" roles in a row"}} 
```

由于客户端侧的情况复杂多样，如果在服务端中重新 convert 请求，可能会引发更多的问题

考虑到函数调用主要是为了向模型提供外部结果，增强其能力和扩展应用场景，对函数调用结果不包含 `AI-generated content` 属于边缘情形，只会影响特定场景下的使用

该已知问题与 #1135 #1187 相关 