### PR TITLE
fix: 修复4v请求下text参数缺少引发的nil

### DIFF
--- a/relay/adaptor/openai/token.go
+++ b/relay/adaptor/openai/token.go
@@ -97,7 +97,11 @@ func CountTokenMessages(messages []model.Message, model string) int {
 				m := it.(map[string]any)
 				switch m["type"] {
 				case "text":
-					tokenNum += getTokenNum(tokenEncoder, m["text"].(string))
+					if textValue, ok := m["text"]; ok {
+						if textString, ok := textValue.(string); ok {
+							tokenNum += getTokenNum(tokenEncoder, textString)
+						}
+					}
 				case "image_url":
 					imageUrl, ok := m["image_url"].(map[string]any)
 					if ok {


### PR DESCRIPTION
close #1633


我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
![image](https://github.com/songquanpeng/one-api/assets/137054651/5853b378-a9a5-4462-8411-ae1fc842dcaa)
![image](https://github.com/songquanpeng/one-api/assets/137054651/97f616b6-1a88-4714-9854-4cd5bf3983a4)
现在不会引发nil了，会最后直接把错错误抛出