### PR TITLE
feat: add field stop in GeneralOpenAIRequest

### DIFF
--- a/relay/model/general.go
+++ b/relay/model/general.go
@@ -13,6 +13,7 @@ type GeneralOpenAIRequest struct {
 	PresencePenalty  float64         `json:"presence_penalty,omitempty"`
 	ResponseFormat   *ResponseFormat `json:"response_format,omitempty"`
 	Seed             float64         `json:"seed,omitempty"`
+	Stop             any             `json:"stop,omitempty"`
 	Stream           bool            `json:"stream,omitempty"`
 	Temperature      float64         `json:"temperature,omitempty"`
 	TopP             float64         `json:"top_p,omitempty"`


### PR DESCRIPTION
问题描述：使用【模型重定向】功能后，one-api 转发对话时丢失 stop 参数。

翻查代码，定位到：
![image](https://github.com/user-attachments/assets/de055705-e41c-45d1-ba51-ba2412c5c8f2)
当 `isModelMapped` 为真，`shouldResetRequestBody` 也为真，调用
`jsonStr, err := json.Marshal(textRequest)` 将 `textRequest` 序列化成字符串。
![image](https://github.com/user-attachments/assets/cde0cc5c-2aac-40e5-aead-b5359001d3a4)
由于 `textRequest` 的类型 `GeneralOpenAIRequest` 并不包含 `stop` 字段，导致模型重定向后字段丢失。

close #1558 
在 issue 搜索了一下，这个 issue 可能遇到类似的情况：
https://github.com/songquanpeng/one-api/issues/1558

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/786d8ee7-1916-41ff-a4eb-c0ef5ade922a)