### PR TITLE
fix: update VertexAI's GetAdaptor function to use the actual model name

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -147,7 +147,6 @@ var InitialRootAccessToken = os.Getenv("INITIAL_ROOT_ACCESS_TOKEN")
 
 var GeminiVersion = env.String("GEMINI_VERSION", "v1")
 
-
 var OnlyOneLogFile = env.Bool("ONLY_ONE_LOG_FILE", false)
 
 var RelayProxy = env.String("RELAY_PROXY", "")

--- a/relay/adaptor/vertexai/adaptor.go
+++ b/relay/adaptor/vertexai/adaptor.go
@@ -19,7 +19,7 @@ var _ adaptor.Adaptor = new(Adaptor)
 
 const channelName = "vertexai"
 
-type Adaptor struct {}
+type Adaptor struct{}
 
 func (a *Adaptor) Init(meta *meta.Meta) {
 }
@@ -38,7 +38,7 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 }
 
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
-	adaptor := GetAdaptor(meta.OriginModelName)
+	adaptor := GetAdaptor(meta.ActualModelName)
 	if adaptor == nil {
 		return nil, &relaymodel.ErrorWithStatusCode{
 			StatusCode: http.StatusInternalServerError,

--- a/relay/adaptor/vertexai/claude/adapter.go
+++ b/relay/adaptor/vertexai/claude/adapter.go
@@ -30,13 +30,13 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 	req := Request{
 		AnthropicVersion: anthropicVersion,
 		// Model:            claudeReq.Model,
-		Messages:         claudeReq.Messages,
-		MaxTokens:        claudeReq.MaxTokens,
-		Temperature:      claudeReq.Temperature,
-		TopP:             claudeReq.TopP,
-		TopK:             claudeReq.TopK,
-		Stream:           claudeReq.Stream,
-		Tools:            claudeReq.Tools,
+		Messages:    claudeReq.Messages,
+		MaxTokens:   claudeReq.MaxTokens,
+		Temperature: claudeReq.Temperature,
+		TopP:        claudeReq.TopP,
+		TopK:        claudeReq.TopK,
+		Stream:      claudeReq.Stream,
+		Tools:       claudeReq.Tools,
 	}
 
 	c.Set(ctxkey.RequestModel, request.Model)

--- a/relay/adaptor/vertexai/claude/model.go
+++ b/relay/adaptor/vertexai/claude/model.go
@@ -4,16 +4,16 @@ import "github.com/songquanpeng/one-api/relay/adaptor/anthropic"
 
 type Request struct {
 	// AnthropicVersion must be "vertex-2023-10-16"
-	AnthropicVersion string              `json:"anthropic_version"`
+	AnthropicVersion string `json:"anthropic_version"`
 	// Model            string              `json:"model"`
-	Messages         []anthropic.Message `json:"messages"`
-	System           string              `json:"system,omitempty"`
-	MaxTokens        int                 `json:"max_tokens,omitempty"`
-	StopSequences    []string            `json:"stop_sequences,omitempty"`
-	Stream           bool                `json:"stream,omitempty"`
-	Temperature      float64             `json:"temperature,omitempty"`
-	TopP             float64             `json:"top_p,omitempty"`
-	TopK             int                 `json:"top_k,omitempty"`
-	Tools            []anthropic.Tool    `json:"tools,omitempty"`
-	ToolChoice       any                 `json:"tool_choice,omitempty"`
+	Messages      []anthropic.Message `json:"messages"`
+	System        string              `json:"system,omitempty"`
+	MaxTokens     int                 `json:"max_tokens,omitempty"`
+	StopSequences []string            `json:"stop_sequences,omitempty"`
+	Stream        bool                `json:"stream,omitempty"`
+	Temperature   float64             `json:"temperature,omitempty"`
+	TopP          float64             `json:"top_p,omitempty"`
+	TopK          int                 `json:"top_k,omitempty"`
+	Tools         []anthropic.Tool    `json:"tools,omitempty"`
+	ToolChoice    any                 `json:"tool_choice,omitempty"`
 }

--- a/relay/adaptor/vertexai/registry.go
+++ b/relay/adaptor/vertexai/registry.go
@@ -32,7 +32,6 @@ func init() {
 	}
 }
 
-
 type innerAIAdapter interface {
 	ConvertRequest(c *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error)
 	DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode)

--- a/relay/adaptor/vertexai/token.go
+++ b/relay/adaptor/vertexai/token.go
@@ -26,7 +26,6 @@ type ApplicationDefaultCredentials struct {
 	UniverseDomain          string `json:"universe_domain"`
 }
 
-
 var Cache = cache.New(50*time.Minute, 55*time.Minute)
 
 const defaultScope = "https://www.googleapis.com/auth/cloud-platform"

--- a/relay/channeltype/url.go
+++ b/relay/channeltype/url.go
@@ -43,7 +43,7 @@ var ChannelBaseURLs = []string{
 	"https://api.together.xyz",                  // 39
 	"https://ark.cn-beijing.volces.com",         // 40
 	"https://api.novita.ai/v3/openai",           // 41
-	"",										     // 42
+	"",                                          // 42
 }
 
 func init() {

--- a/relay/meta/relay_meta.go
+++ b/relay/meta/relay_meta.go
@@ -10,20 +10,22 @@ import (
 )
 
 type Meta struct {
-	Mode            int
-	ChannelType     int
-	ChannelId       int
-	TokenId         int
-	TokenName       string
-	UserId          int
-	Group           string
-	ModelMapping    map[string]string
-	BaseURL         string
-	APIKey          string
-	APIType         int
-	Config          model.ChannelConfig
-	IsStream        bool
+	Mode         int
+	ChannelType  int
+	ChannelId    int
+	TokenId      int
+	TokenName    string
+	UserId       int
+	Group        string
+	ModelMapping map[string]string
+	BaseURL      string
+	APIKey       string
+	APIType      int
+	Config       model.ChannelConfig
+	IsStream     bool
+	// OriginModelName is the model name from the raw user request
 	OriginModelName string
+	// ActualModelName is the model name after mapping
 	ActualModelName string
 	RequestURLPath  string
 	PromptTokens    int // only for DoResponse


### PR DESCRIPTION
## 问题

vertex adaptor 的 `GetAdaptor` 有 BUG，原代码是用 `OriginModelName`，如果 user request 使用了别名，会导致无法查找到 adaptor。

## 修复

改用 `ActualModelName` 即可。

顺带跑了一下 `gofmt`，做了一些自动格式化。

## 自测

![CleanShot 2024-07-15 at 14 34 29@2x](https://github.com/user-attachments/assets/320088b7-0ffb-4544-aa79-307eafde4c38)
