### PR TITLE
feat: add Max Tokens and Context Window Setting Options for Ollama Channel

### DIFF
--- a/relay/adaptor/ollama/main.go
+++ b/relay/adaptor/ollama/main.go
@@ -119,10 +119,7 @@ func StreamHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusC
 	common.SetEventStreamHeaders(c)
 
 	for scanner.Scan() {
-		line := scanner.Text()
-		fmt.Println("Scanned line:", line)
-		data := strings.TrimPrefix(scanner.Text(), "}")
-		data = data + "}"
+		data := scanner.Text()
 
 		var ollamaResponse ChatResponse
 		err := json.Unmarshal([]byte(data), &ollamaResponse)

--- a/relay/adaptor/ollama/main.go
+++ b/relay/adaptor/ollama/main.go
@@ -31,7 +31,8 @@ func ConvertRequest(request model.GeneralOpenAIRequest) *ChatRequest {
 			TopP:             request.TopP,
 			FrequencyPenalty: request.FrequencyPenalty,
 			PresencePenalty:  request.PresencePenalty,
-			NumPredict:  request.MaxTokens,
+			NumPredict:  	  request.MaxTokens,
+			NumCtx:  	  request.NumCtx,
 		},
 		Stream: request.Stream,
 	}

--- a/relay/adaptor/ollama/main.go
+++ b/relay/adaptor/ollama/main.go
@@ -121,6 +121,9 @@ func StreamHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusC
 
 	for scanner.Scan() {
 		data := scanner.Text()
+		if strings.HasPrefix(data, "}") {
+		    data = strings.TrimPrefix(data, "}") + "}"
+		}
 
 		var ollamaResponse ChatResponse
 		err := json.Unmarshal([]byte(data), &ollamaResponse)

--- a/relay/adaptor/ollama/main.go
+++ b/relay/adaptor/ollama/main.go
@@ -119,6 +119,8 @@ func StreamHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusC
 	common.SetEventStreamHeaders(c)
 
 	for scanner.Scan() {
+		line := scanner.Text()
+		fmt.Println("Scanned line:", line)
 		data := strings.TrimPrefix(scanner.Text(), "}")
 		data = data + "}"
 

--- a/relay/adaptor/ollama/main.go
+++ b/relay/adaptor/ollama/main.go
@@ -31,6 +31,7 @@ func ConvertRequest(request model.GeneralOpenAIRequest) *ChatRequest {
 			TopP:             request.TopP,
 			FrequencyPenalty: request.FrequencyPenalty,
 			PresencePenalty:  request.PresencePenalty,
+			NumPredict:  request.MaxTokens,
 		},
 		Stream: request.Stream,
 	}

--- a/relay/adaptor/ollama/model.go
+++ b/relay/adaptor/ollama/model.go
@@ -7,6 +7,7 @@ type Options struct {
 	TopP             float64 `json:"top_p,omitempty"`
 	FrequencyPenalty float64 `json:"frequency_penalty,omitempty"`
 	PresencePenalty  float64 `json:"presence_penalty,omitempty"`
+	NumPredict  float64 `json:"num_predict,omitempty"`
 }
 
 type Message struct {

--- a/relay/adaptor/ollama/model.go
+++ b/relay/adaptor/ollama/model.go
@@ -7,7 +7,7 @@ type Options struct {
 	TopP             float64 `json:"top_p,omitempty"`
 	FrequencyPenalty float64 `json:"frequency_penalty,omitempty"`
 	PresencePenalty  float64 `json:"presence_penalty,omitempty"`
-	NumPredict  float64 `json:"num_predict,omitempty"`
+	NumPredict  int `json:"num_predict,omitempty"`
 }
 
 type Message struct {

--- a/relay/adaptor/ollama/model.go
+++ b/relay/adaptor/ollama/model.go
@@ -7,7 +7,8 @@ type Options struct {
 	TopP             float64 `json:"top_p,omitempty"`
 	FrequencyPenalty float64 `json:"frequency_penalty,omitempty"`
 	PresencePenalty  float64 `json:"presence_penalty,omitempty"`
-	NumPredict  int `json:"num_predict,omitempty"`
+	NumPredict  	 int 	 `json:"num_predict,omitempty"`
+	NumCtx  	 int 	 `json:"num_ctx,omitempty"`
 }
 
 type Message struct {

--- a/relay/model/general.go
+++ b/relay/model/general.go
@@ -29,6 +29,7 @@ type GeneralOpenAIRequest struct {
 	Dimensions       int             `json:"dimensions,omitempty"`
 	Instruction      string          `json:"instruction,omitempty"`
 	Size             string          `json:"size,omitempty"`
+	NumCtx           int         	 `json:"num_ctx,omitempty"`
 }
 
 func (r GeneralOpenAIRequest) ParseInput() []string {


### PR DESCRIPTION
**已实现：**
1. 支持通过`max_tokens`（对应ollama的num_predict）参数限制输出token数
2. 支持通过`num_ctx`（ollama原生参数）参数设定更改ollama默认context window大小（默认仅1k/2k上下文）

**有个问题：**
下图中改动的部分是因为原本的代码会导致报错，console打印后发现原本的data就是正确的json格式不需要对花括号进行增减处理。但奇怪的是目前我通过docker compose部署的正式版本也是能正常使用的，正式版本并没有我对这两行的修改（也可能部署的版本本来没有这两行？没有去查看，总之修改之后添加了条件判断，对两种不同状况都能有效应对）。
目前已确认并非个案， #1702 也是同样的问题，但我觉得条件判断会比直接改掉健壮性更强
![image](https://github.com/user-attachments/assets/cc8a2992-cd72-4816-ac59-dd83de21196b)

close #1691

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/08753ffe-7b02-46dc-a838-03f1e96cf544)
![image](https://github.com/user-attachments/assets/00293bd3-c194-42fc-8452-bce4ce6e29e6)
