### PR TITLE
chore: Add Cloudflare New Free Model Llama 3.1 8b

### DIFF
--- a/relay/adaptor/cloudflare/constant.go
+++ b/relay/adaptor/cloudflare/constant.go
@@ -1,6 +1,7 @@
 package cloudflare
 
 var ModelList = []string{
+	"@cf/meta/llama-3.1-8b-instruct",
 	"@cf/meta/llama-2-7b-chat-fp16",
 	"@cf/meta/llama-2-7b-chat-int8",
 	"@cf/mistral/mistral-7b-instruct-v0.1",


### PR DESCRIPTION
新增Cloudflare支持的免费Beta模型 Llama 3.1 8b

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
![截屏2024-07-31 17 19 32](https://github.com/user-attachments/assets/2e40f6b5-1138-4502-9295-227079213851)
