### PR TITLE
feat: support new openai models (4o 0806, chatgpt-4o-latest)

### DIFF
--- a/relay/adaptor/openai/constants.go
+++ b/relay/adaptor/openai/constants.go
@@ -8,6 +8,7 @@ var ModelList = []string{
 	"gpt-4-32k", "gpt-4-32k-0314", "gpt-4-32k-0613",
 	"gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4-turbo-2024-04-09",
 	"gpt-4o", "gpt-4o-2024-05-13",
+	"gpt-4o-2024-08-06",
 	"gpt-4o-mini", "gpt-4o-mini-2024-07-18",
 	"gpt-4-vision-preview",
 	"text-embedding-ada-002", "text-embedding-3-small", "text-embedding-3-large",

--- a/relay/adaptor/openai/constants.go
+++ b/relay/adaptor/openai/constants.go
@@ -9,6 +9,7 @@ var ModelList = []string{
 	"gpt-4-turbo-preview", "gpt-4-turbo", "gpt-4-turbo-2024-04-09",
 	"gpt-4o", "gpt-4o-2024-05-13",
 	"gpt-4o-2024-08-06",
+	"chatgpt-4o-latest",
 	"gpt-4o-mini", "gpt-4o-mini-2024-07-18",
 	"gpt-4-vision-preview",
 	"text-embedding-ada-002", "text-embedding-3-small", "text-embedding-3-large",

--- a/relay/billing/ratio/model.go
+++ b/relay/billing/ratio/model.go
@@ -34,6 +34,7 @@ var ModelRatio = map[string]float64{
 	"gpt-4-turbo":             5,     // $0.01 / 1K tokens
 	"gpt-4-turbo-2024-04-09":  5,     // $0.01 / 1K tokens
 	"gpt-4o":                  2.5,   // $0.005 / 1K tokens
+	"chatgpt-4o-latest":       2.5,   // $0.005 / 1K tokens
 	"gpt-4o-2024-05-13":       2.5,   // $0.005 / 1K tokens
 	"gpt-4o-2024-08-06":       1.25,  // $0.0025 / 1K tokens
 	"gpt-4o-mini":             0.075, // $0.00015 / 1K tokens
@@ -323,6 +324,9 @@ func GetCompletionRatio(name string, channelType int) float64 {
 			return 3
 		}
 		return 2
+	}
+	if name == "chatgpt-4o-latest" {
+		return 3
 	}
 	if strings.HasPrefix(name, "claude-3") {
 		return 5

--- a/relay/billing/ratio/model.go
+++ b/relay/billing/ratio/model.go
@@ -35,6 +35,7 @@ var ModelRatio = map[string]float64{
 	"gpt-4-turbo-2024-04-09":  5,     // $0.01 / 1K tokens
 	"gpt-4o":                  2.5,   // $0.005 / 1K tokens
 	"gpt-4o-2024-05-13":       2.5,   // $0.005 / 1K tokens
+	"gpt-4o-2024-08-06":       1.25,  // $0.0025 / 1K tokens
 	"gpt-4o-mini":             0.075, // $0.00015 / 1K tokens
 	"gpt-4o-mini-2024-07-18":  0.075, // $0.00015 / 1K tokens
 	"gpt-4-vision-preview":    5,     // $0.01 / 1K tokens
@@ -313,7 +314,7 @@ func GetCompletionRatio(name string, channelType int) float64 {
 		return 4.0 / 3.0
 	}
 	if strings.HasPrefix(name, "gpt-4") {
-		if strings.HasPrefix(name, "gpt-4o-mini") {
+		if strings.HasPrefix(name, "gpt-4o-mini") || name == "gpt-4o-2024-08-06" {
 			return 4
 		}
 		if strings.HasPrefix(name, "gpt-4-turbo") ||


### PR DESCRIPTION
[//]: # (请按照以下格式关联 issue)
[//]: # (请在提交 PR 前确认所提交的功能可用，需要附上截图，谢谢)
[//]: # (项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解)
[//]: # (开发者交流群：910657413)
[//]: # (请在提交 PR 之前删除上面的注释)

ref: https://openai.com/index/introducing-structured-outputs-in-the-api/


> 通过切换到新的gpt-4o-2024-08-06, developers save 50% on inputs ($2.50/1M input tokens) and 33% on outputs ($10.00/1M output tokens) compared to gpt-4o-2024-05-13.


> 与 gpt-4o-2024-05-13 相比，开发者可节省 50%的输入成本（每百万输入令牌$2.50）和 33%的输出成本（每百万输出令牌$10.00）

卷起来！

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
![image](https://github.com/user-attachments/assets/411a3818-17cf-45ac-b4ca-dfe812c67252)