### PR TITLE
fix: modify the type of token models to be text

### DIFF
--- a/model/token.go
+++ b/model/token.go
@@ -30,7 +30,7 @@ type Token struct {
 	RemainQuota    int64   `json:"remain_quota" gorm:"bigint;default:0"`
 	UnlimitedQuota bool    `json:"unlimited_quota" gorm:"default:false"`
 	UsedQuota      int64   `json:"used_quota" gorm:"bigint;default:0"` // used quota
-	Models         *string `json:"models" gorm:"default:''"`           // allowed models
+	Models         *string `json:"models" gorm:"type:text"`           // allowed models
 	Subnet         *string `json:"subnet" gorm:"default:''"`           // allowed subnet
 }
 

--- a/model/token.go
+++ b/model/token.go
@@ -30,7 +30,7 @@ type Token struct {
 	RemainQuota    int64   `json:"remain_quota" gorm:"bigint;default:0"`
 	UnlimitedQuota bool    `json:"unlimited_quota" gorm:"default:false"`
 	UsedQuota      int64   `json:"used_quota" gorm:"bigint;default:0"` // used quota
-	Models         *string `json:"models" gorm:"type:text"`           // allowed models
+	Models         *string `json:"models" gorm:"type:text"`            // allowed models
 	Subnet         *string `json:"subnet" gorm:"default:''"`           // allowed subnet
 }
 
@@ -121,28 +121,38 @@ func GetTokenById(id int) (*Token, error) {
 	return &token, err
 }
 
-func (token *Token) Insert() error {
+func (t *Token) Insert() error {
 	var err error
-	err = DB.Create(token).Error
+	err = DB.Create(t).Error
 	return err
 }
 
 // Update Make sure your token's fields is completed, because this will update non-zero values
-func (token *Token) Update() error {
+func (t *Token) Update() error {
 	var err error
-	err = DB.Model(token).Select("name", "status", "expired_time", "remain_quota", "unlimited_quota", "models", "subnet").Updates(token).Error
+	err = DB.Model(t).Select("name", "status", "expired_time", "remain_quota", "unlimited_quota", "models", "subnet").Updates(t).Error
 	return err
 }
 
-func (token *Token) SelectUpdate() error {
+func (t *Token) SelectUpdate() error {
 	// This can update zero values
-	return DB.Model(token).Select("accessed_time", "status").Updates(token).Error
+	return DB.Model(t).Select("accessed_time", "status").Updates(t).Error
 }
 
-func (token *Token) Delete() error {
+func (t *Token) Delete() error {
 	var err error
-	err = DB.Delete(token).Error
+	err = DB.Delete(t).Error
 	return err
+}
+
+func (t *Token) GetModels() string {
+	if t == nil {
+		return ""
+	}
+	if t.Models == nil {
+		return ""
+	}
+	return *t.Models
 }
 
 func DeleteTokenById(id int, userId int) (err error) {


### PR DESCRIPTION

close #issue_number

If MySQL is used as the database, the default data type for "token models" is "varchar(191)". When we create a token object with many models, the model data string will be truncated in the database.

在使用 MySQL 作为数据库时， tokens 表中的 models 字段的类型是 varchar， 当创建 token 时配置的模型数量过多时，会导致数据不能完全保存。

有另外一个有点关系的 issue：  #1483


我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
![image](https://github.com/user-attachments/assets/96c8f7a2-7e0d-46c3-bb30-87bb8cc814e1)
![image](https://github.com/user-attachments/assets/bc767274-938d-4f18-a26f-38bb0e890b90)

