### PR TITLE
fix: return the usage info if usage not null

### DIFF
--- a/relay/adaptor/openai/main.go
+++ b/relay/adaptor/openai/main.go
@@ -55,8 +55,8 @@ func StreamHandler(c *gin.Context, resp *http.Response, relayMode int) (*model.E
 				render.StringData(c, data) // if error happened, pass the data to client
 				continue                   // just ignore the error
 			}
-			if len(streamResponse.Choices) == 0 {
-				// but for empty choice, we should not pass it to client, this is for azure
+			if len(streamResponse.Choices) == 0 && streamResponse.Usage == nil {
+				// but for empty choice and no usage, we should not pass it to client, this is for azure
 				continue // just ignore empty choice
 			}
 			render.StringData(c, data)


### PR DESCRIPTION
The usage is missing.

close #no_issue

The change  is verified in the self-hosted service.