### PR TITLE
fix: Groq organization not auto-disabled when blocked

### DIFF
--- a/monitor/manage.go
+++ b/monitor/manage.go
@@ -45,6 +45,9 @@ func ShouldDisableChannel(err *model.Error, statusCode int) bool {
 	if strings.Contains(err.Message, "balance") {
 		return true
 	}
+	if strings.Contains(err.Message, "Organization has been restricted") { // groq
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
[]: # (请按照以下格式关联 issue)
[]: # (请在提交 PR 前确认所提交的功能可用，需要附上截图，谢谢)
[]: # (项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解)
[]: # (开发者交流群：910657413)
[]: # (请在提交 PR 之前删除上面的注释)

close #1764  

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
![11](https://github.com/user-attachments/assets/890232b1-5ae3-4c83-a570-97c748e7a921)
