### PR TITLE
V0.6.9 alpha 1008

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,15 @@ COPY ./VERSION .
 COPY ./web .
 
 WORKDIR /web/default
-RUN npm install
+RUN npm config set registry https://mirrors.huaweicloud.com/repository/npm/ && npm install
 RUN DISABLE_ESLINT_PLUGIN='true' REACT_APP_VERSION=$(cat VERSION) npm run build
 
 WORKDIR /web/berry
-RUN npm install
+RUN npm config set registry https://mirrors.huaweicloud.com/repository/npm/ && npm install
 RUN DISABLE_ESLINT_PLUGIN='true' REACT_APP_VERSION=$(cat VERSION) npm run build
 
 WORKDIR /web/air
-RUN npm install
+RUN npm config set registry https://mirrors.huaweicloud.com/repository/npm/ && npm install
 RUN DISABLE_ESLINT_PLUGIN='true' REACT_APP_VERSION=$(cat VERSION) npm run build
 
 FROM golang:alpine AS builder2

--- a/relay/adaptor/ali/main.go
+++ b/relay/adaptor/ali/main.go
@@ -202,7 +202,8 @@ func StreamHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusC
 
 		// Check for known error codes and handle accordingly
 		if aliResponse.Code != "" {
-			return &model.ErrorWithStatusCode{
+
+			errorResponse := &model.ErrorWithStatusCode{
 				Error: model.Error{
 					Message: aliResponse.Message,
 					Type:    aliResponse.Code,
@@ -210,7 +211,14 @@ func StreamHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusC
 					Code:    aliResponse.Code,
 				},
 				StatusCode: resp.StatusCode,
-			}, nil
+			}
+
+			err = render.ObjectData(c, errorResponse)
+			if err != nil {
+				logger.SysError(err.Error())
+			}
+			render.Done(c)
+			return nil, nil
 		}
 
 		if aliResponse.Usage.OutputTokens != 0 {

--- a/relay/adaptor/openai/model.go
+++ b/relay/adaptor/openai/model.go
@@ -97,6 +97,16 @@ type TextResponse struct {
 	model.Usage `json:"usage"`
 }
 
+type ErrorTextResponse struct {
+	Id          string               `json:"id"`
+	Model       string               `json:"model,omitempty"`
+	Object      string               `json:"object"`
+	ErrorCode   string               `json:"error_code"`
+	Created     int64                `json:"created"`
+	Choices     []TextResponseChoice `json:"choices"`
+	model.Usage `json:"usage"`
+}
+
 type EmbeddingResponseItem struct {
 	Object    string    `json:"object"`
 	Index     int       `json:"index"`
@@ -135,6 +145,16 @@ type ChatCompletionsStreamResponse struct {
 	Model   string                                `json:"model"`
 	Choices []ChatCompletionsStreamResponseChoice `json:"choices"`
 	Usage   *model.Usage                          `json:"usage,omitempty"`
+}
+
+type ChatCompletionsErrorStreamResponse struct {
+	Id        string                                `json:"id"`
+	Object    string                                `json:"object"`
+	Created   int64                                 `json:"created"`
+	ErrorCode string                                `json:"error_code"`
+	Model     string                                `json:"model"`
+	Choices   []ChatCompletionsStreamResponseChoice `json:"choices"`
+	Usage     *model.Usage                          `json:"usage,omitempty"`
 }
 
 type CompletionsStreamResponse struct {


### PR DESCRIPTION
pr解决的问题：
1. 使用阿里云官网的qwen时，如果遇到敏感问题，one api会直接不返回任何内容，调用侧误认为是BUG，当前是将qwen的错误透传给调用侧，主要改进的是流式，在公司内部已正常使用，且调用侧改动非常小。

我已确认该 PR 已自测通过，相关截图如下：
不敏感时，和原来一致：
![image](https://github.com/user-attachments/assets/cc81ed60-ceec-4d59-aebf-875e11835b8c)

有敏感问题时：
![image](https://github.com/user-attachments/assets/6fa668c0-554d-4ee7-a849-139b67e70c4a)

