### PR TITLE
feat: add support for Claude Sonnet 3.5 v2

### DIFF
--- a/relay/adaptor/anthropic/constants.go
+++ b/relay/adaptor/anthropic/constants.go
@@ -6,4 +6,5 @@ var ModelList = []string{
 	"claude-3-sonnet-20240229",
 	"claude-3-opus-20240229",
 	"claude-3-5-sonnet-20240620",
+	"claude-3-5-sonnet-20241022",
 }

--- a/relay/adaptor/aws/claude/main.go
+++ b/relay/adaptor/aws/claude/main.go
@@ -31,6 +31,7 @@ var AwsModelIDMap = map[string]string{
 	"claude-2.1":                 "anthropic.claude-v2:1",
 	"claude-3-sonnet-20240229":   "anthropic.claude-3-sonnet-20240229-v1:0",
 	"claude-3-5-sonnet-20240620": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+	"claude-3-5-sonnet-20241022": "anthropic.claude-3-5-sonnet-20241022-v2:0",
 	"claude-3-opus-20240229":     "anthropic.claude-3-opus-20240229-v1:0",
 	"claude-3-haiku-20240307":    "anthropic.claude-3-haiku-20240307-v1:0",
 }

--- a/relay/billing/ratio/model.go
+++ b/relay/billing/ratio/model.go
@@ -81,6 +81,7 @@ var ModelRatio = map[string]float64{
 	"claude-3-haiku-20240307":    0.25 / 1000 * USD,
 	"claude-3-sonnet-20240229":   3.0 / 1000 * USD,
 	"claude-3-5-sonnet-20240620": 3.0 / 1000 * USD,
+	"claude-3-5-sonnet-20241022": 3.0 / 1000 * USD,
 	"claude-3-opus-20240229":     15.0 / 1000 * USD,
 	// https://cloud.baidu.com/doc/WENXINWORKSHOP/s/hlrk4akp7
 	"ERNIE-4.0-8K":       0.120 * RMB,

--- a/web/air/src/pages/Channel/EditChannel.js
+++ b/web/air/src/pages/Channel/EditChannel.js
@@ -63,7 +63,7 @@ const EditChannel = (props) => {
             let localModels = [];
             switch (value) {
                 case 14:
-                    localModels = ["claude-instant-1.2", "claude-2", "claude-2.0", "claude-2.1", "claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-3-haiku-20240307", "claude-3-5-sonnet-20240620"];
+                    localModels = ["claude-instant-1.2", "claude-2", "claude-2.0", "claude-2.1", "claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-3-haiku-20240307", "claude-3-5-sonnet-20240620", "claude-3-5-sonnet-20241022"];
                     break;
                 case 11:
                     localModels = ['PaLM-2'];


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2f397aa2-3978-4faf-b25f-da7e45012cbe)
增加 anthropic.claude-3-5-sonnet-20241022-v2:0
我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
