### PR TITLE
fix: update Spark Lite's domain to lite

### DIFF
--- a/relay/adaptor/xunfei/main.go
+++ b/relay/adaptor/xunfei/main.go
@@ -283,7 +283,7 @@ func parseAPIVersionByModelName(modelName string) string {
 func apiVersion2domain(apiVersion string) string {
 	switch apiVersion {
 	case "v1.1":
-		return "general"
+		return "lite"
 	case "v2.1":
 		return "generalv2"
 	case "v3.1":


### PR DESCRIPTION
close #1886

我已确认该 PR 已自测通过，相关截图如下：
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/f3bdf0c4-112f-45ce-a6f9-b1d0aa82528e">
