### PR TITLE
fix:修复在渠道配置中设置模型重定向时，temperature为0被忽略的问题

### DIFF
--- a/relay/model/general.go
+++ b/relay/model/general.go
@@ -35,7 +35,7 @@ type GeneralOpenAIRequest struct {
 	Stop             any             `json:"stop,omitempty"`
 	Stream           bool            `json:"stream,omitempty"`
 	StreamOptions    *StreamOptions  `json:"stream_options,omitempty"`
-	Temperature      float64         `json:"temperature,omitempty"`
+	Temperature      float64         `json:"temperature"`
 	TopP             float64         `json:"top_p,omitempty"`
 	TopK             int             `json:"top_k,omitempty"`
 	Tools            []Tool          `json:"tools,omitempty"`


### PR DESCRIPTION
修复了如果在渠道配置里，配置了模型重定向时，会使用json进行转换
![image](https://github.com/user-attachments/assets/a91b4c8b-b91d-4504-aa84-5180d7d4f76e)

GeneralOpenAIRequest里的Temperature设置了omitempty标签，会导致temperature传0时被自动忽略，导致大模型使用默认的t
temperature
![image](https://github.com/user-attachments/assets/4e919fbb-fa37-4850-84cd-60849da924a0)

close #904

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/8295ff1d-b3cd-44d9-9bf2-c46c54c69a8c)

