### PR TITLE
支持讯飞星火微调平台微调模型

### DIFF
--- a/common/ctxkey/key.go
+++ b/common/ctxkey/key.go
@@ -21,4 +21,5 @@ const (
 	AvailableModels   = "available_models"
 	KeyRequestBody    = "key_request_body"
 	SystemPrompt      = "system_prompt"
+	LoraId            = "lora_id"
 )

--- a/relay/adaptor/xunfei/main.go
+++ b/relay/adaptor/xunfei/main.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -205,6 +206,10 @@ func Handler(c *gin.Context, meta *meta.Meta, textRequest model.GeneralOpenAIReq
 			usage.TotalTokens += xunfeiResponse.Payload.Usage.Text.TotalTokens
 		case stop = <-stopChan:
 		}
+	}
+	if xunfeiResponse.Header.Code != 0 {
+		return openai.ErrorWrapper(errors.New("xunfei response error: sid: "+xunfeiResponse.Header.Sid), strconv.Itoa(xunfeiResponse.Header.Code), http.StatusInternalServerError), nil
+
 	}
 	if len(xunfeiResponse.Payload.Choices.Text) == 0 {
 		return openai.ErrorWrapper(errors.New("xunfei empty response detected"), "xunfei_empty_response_detected", http.StatusInternalServerError), nil

--- a/relay/adaptor/xunfei/main.go
+++ b/relay/adaptor/xunfei/main.go
@@ -97,7 +97,7 @@ func responseXunfei2OpenAI(response *ChatResponse) *openai.TextResponse {
 		FinishReason: constant.StopFinishReason,
 	}
 	fullTextResponse := openai.TextResponse{
-		Id:      fmt.Sprintf("chatcmpl-%s", random.GetUUID()),
+		Id:      response.Header.Sid,
 		Object:  "chat.completion",
 		Created: helper.GetTimestamp(),
 		Choices: []openai.TextResponseChoice{choice},

--- a/relay/adaptor/xunfei/main.go
+++ b/relay/adaptor/xunfei/main.go
@@ -153,7 +153,7 @@ func buildXunfeiAuthUrl(hostUrl string, apiKey, apiSecret string) string {
 }
 
 func StreamHandler(c *gin.Context, meta *meta.Meta, textRequest model.GeneralOpenAIRequest, appId string, apiSecret string, apiKey string) (*model.ErrorWithStatusCode, *model.Usage) {
-	domain, authUrl := getXunfeiAuthUrl(meta.Config.APIVersion, apiKey, apiSecret)
+	domain, authUrl := getXunfeiAuthUrl(meta.Config.APIVersion, apiKey, apiSecret, textRequest.Model)
 	dataChan, stopChan, err := xunfeiMakeRequest(textRequest, domain, authUrl, appId)
 	if err != nil {
 		return openai.ErrorWrapper(err, "xunfei_request_failed", http.StatusInternalServerError), nil
@@ -183,7 +183,7 @@ func StreamHandler(c *gin.Context, meta *meta.Meta, textRequest model.GeneralOpe
 }
 
 func Handler(c *gin.Context, meta *meta.Meta, textRequest model.GeneralOpenAIRequest, appId string, apiSecret string, apiKey string) (*model.ErrorWithStatusCode, *model.Usage) {
-	domain, authUrl := getXunfeiAuthUrl(meta.Config.APIVersion, apiKey, apiSecret)
+	domain, authUrl := getXunfeiAuthUrl(meta.Config.APIVersion, apiKey, apiSecret, textRequest.Model)
 	dataChan, stopChan, err := xunfeiMakeRequest(textRequest, domain, authUrl, appId)
 	if err != nil {
 		return openai.ErrorWrapper(err, "xunfei_request_failed", http.StatusInternalServerError), nil
@@ -300,7 +300,7 @@ func apiVersion2domain(apiVersion string) string {
 	return "general" + apiVersion
 }
 
-func getXunfeiAuthUrl(apiVersion string, apiKey string, apiSecret string) (string, string) {
+func getXunfeiAuthUrl(apiVersion string, apiKey string, apiSecret string, modelName string) (string, string) {
 	var authUrl string
 	domain := apiVersion2domain(apiVersion)
 	switch apiVersion {
@@ -310,6 +310,13 @@ func getXunfeiAuthUrl(apiVersion string, apiKey string, apiSecret string) (strin
 	case "v3.5-32K":
 		authUrl = buildXunfeiAuthUrl(fmt.Sprintf("wss://spark-api.xf-yun.com/chat/max-32k"), apiKey, apiSecret)
 		break
+	case "maas":
+		domain = modelName
+		authUrl = buildXunfeiAuthUrl(fmt.Sprintf("wss://maas-api.cn-huabei-1.xf-yun.com/%s/chat", apiVersion), apiKey, apiSecret)
+	case "xingchen":
+		domain = modelName
+		authUrl = buildXunfeiAuthUrl(fmt.Sprintf("wss://xingcheng-api.cn-huabei-1.xf-yun.com/%s/chat", apiVersion), apiKey, apiSecret)
+
 	default:
 		authUrl = buildXunfeiAuthUrl(fmt.Sprintf("wss://spark-api.xf-yun.com/%s/chat", apiVersion), apiKey, apiSecret)
 	}

--- a/relay/adaptor/xunfei/main.go
+++ b/relay/adaptor/xunfei/main.go
@@ -312,10 +312,10 @@ func getXunfeiAuthUrl(apiVersion string, apiKey string, apiSecret string, modelN
 		break
 	case "maas":
 		domain = modelName
-		authUrl = buildXunfeiAuthUrl(fmt.Sprintf("wss://maas-api.cn-huabei-1.xf-yun.com/%s/chat", apiVersion), apiKey, apiSecret)
+		authUrl = buildXunfeiAuthUrl(fmt.Sprintf("wss://maas-api.cn-huabei-1.xf-yun.com/v1.1/chat"), apiKey, apiSecret)
 	case "xingchen":
 		domain = modelName
-		authUrl = buildXunfeiAuthUrl(fmt.Sprintf("wss://xingcheng-api.cn-huabei-1.xf-yun.com/%s/chat", apiVersion), apiKey, apiSecret)
+		authUrl = buildXunfeiAuthUrl(fmt.Sprintf("wss://xingcheng-api.cn-huabei-1.xf-yun.com/v1.1/chat"), apiKey, apiSecret)
 
 	default:
 		authUrl = buildXunfeiAuthUrl(fmt.Sprintf("wss://spark-api.xf-yun.com/%s/chat", apiVersion), apiKey, apiSecret)

--- a/relay/adaptor/xunfei/main.go
+++ b/relay/adaptor/xunfei/main.go
@@ -39,7 +39,9 @@ func requestOpenAI2Xunfei(request model.GeneralOpenAIRequest, xunfeiAppId string
 	}
 	xunfeiRequest := ChatRequest{}
 	xunfeiRequest.Header.AppId = xunfeiAppId
-	xunfeiRequest.Header.PatchId = xunfeiPatchId
+	if xunfeiPatchId != "" {
+		xunfeiRequest.Header.PatchId = []string{xunfeiPatchId}
+	}
 	xunfeiRequest.Parameter.Chat.Domain = domain
 	xunfeiRequest.Parameter.Chat.Temperature = request.Temperature
 	xunfeiRequest.Parameter.Chat.TopK = request.N

--- a/relay/adaptor/xunfei/model.go
+++ b/relay/adaptor/xunfei/model.go
@@ -15,7 +15,8 @@ type Functions struct {
 
 type ChatRequest struct {
 	Header struct {
-		AppId string `json:"app_id"`
+		AppId   string `json:"app_id"`
+		PatchId string `json:"patch_id,omitempty"`
 	} `json:"header"`
 	Parameter struct {
 		Chat struct {

--- a/relay/adaptor/xunfei/model.go
+++ b/relay/adaptor/xunfei/model.go
@@ -15,8 +15,8 @@ type Functions struct {
 
 type ChatRequest struct {
 	Header struct {
-		AppId   string `json:"app_id"`
-		PatchId string `json:"patch_id,omitempty"`
+		AppId   string   `json:"app_id"`
+		PatchId []string `json:"patch_id,omitempty"`
 	} `json:"header"`
 	Parameter struct {
 		Chat struct {

--- a/relay/meta/relay_meta.go
+++ b/relay/meta/relay_meta.go
@@ -31,6 +31,9 @@ type Meta struct {
 	RequestURLPath  string
 	PromptTokens    int // only for DoResponse
 	SystemPrompt    string
+
+	//Lora_id
+	LoraId string
 }
 
 func GetByContext(c *gin.Context) *Meta {
@@ -48,6 +51,7 @@ func GetByContext(c *gin.Context) *Meta {
 		APIKey:          strings.TrimPrefix(c.Request.Header.Get("Authorization"), "Bearer "),
 		RequestURLPath:  c.Request.URL.String(),
 		SystemPrompt:    c.GetString(ctxkey.SystemPrompt),
+		LoraId:          c.Request.Header.Get(ctxkey.LoraId),
 	}
 	cfg, ok := c.Get(ctxkey.Config)
 	if ok {


### PR DESCRIPTION

新特性
[*] 支持[星火maas平台](https://training.xfyun.cn/)微调后模型部署的API， 欢迎使用
[*] Meta信息添加支持 LoraID，用户可以通过OpenAI的客户端或者 Httpclient设置 extra body:  lora_id: <your_lora_id> 来访问lora小包模型
[*] 响应设置 random.uuid 替换为讯飞返回SID
[*] 讯飞响应报错返回讯飞Code信息

 
我已确认该 PR 已自测通过，相关截图如下：
使用方法:

1. 使用Maas微调模型:

![image](https://github.com/user-attachments/assets/4e78a9b1-6ad1-4796-b8ef-7c8d8073c290)
2. 使用Lora_ID
<img width="685" alt="image" src="https://github.com/user-attachments/assets/a971c9c7-c8a5-43a6-8d68-29bf3bd37545">
3. 响应设置讯飞sid
<img width="853" alt="image" src="https://github.com/user-attachments/assets/c48c3816-914a-4bfc-a28d-11d2aed1b812">

其中Lora_ID ，我有想考虑放到平台配置上， 不过这样得改动web~



