### PR TITLE
fix: remove the duplicate `claude-3-5-haiku-20241022` in Anthropic's base model list

### DIFF
--- a/relay/adaptor/anthropic/constants.go
+++ b/relay/adaptor/anthropic/constants.go
@@ -8,6 +8,5 @@ var ModelList = []string{
 	"claude-3-opus-20240229",
 	"claude-3-5-sonnet-20240620",
 	"claude-3-5-sonnet-20241022",
-	"claude-3-5-sonnet-latest",
-	"claude-3-5-haiku-20241022",
+	"claude-3-5-sonnet-latest"
 }

--- a/relay/adaptor/anthropic/constants.go
+++ b/relay/adaptor/anthropic/constants.go
@@ -8,5 +8,5 @@ var ModelList = []string{
 	"claude-3-opus-20240229",
 	"claude-3-5-sonnet-20240620",
 	"claude-3-5-sonnet-20241022",
-	"claude-3-5-sonnet-latest"
+	"claude-3-5-sonnet-latest",
 }


### PR DESCRIPTION
Remove the duplicate `claude-3-5-haiku-20241022` causing issue 1928

[//]: # (请按照以下格式关联 issue)
[//]: # (请在提交 PR 前确认所提交的功能可用，需要附上截图，谢谢)
[//]: # (项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解)
[//]: # (开发者交流群：910657413)
[//]: # (请在提交 PR 之前删除上面的注释)

close #1928 

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
过于浅显的错误，我就不 build 了……