### PR TITLE
fix: fix balance query for siliconflow

### DIFF
--- a/controller/channel-billing.go
+++ b/controller/channel-billing.go
@@ -237,7 +237,7 @@ func updateChannelSiliconFlowBalance(channel *model.Channel) (float64, error) {
 	if response.Code != 20000 {
 		return 0, fmt.Errorf("code: %d, message: %s", response.Code, response.Message)
 	}
-	balance, err := strconv.ParseFloat(response.Data.Balance, 64)
+	balance, err := strconv.ParseFloat(response.Data.TotalBalance, 64)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
之前余额查询用的是 balance 属性，但实际上应当是 totalBalance 属性，前者只包含赠送的余额。

具体可以参考 [API文档](https://docs.siliconflow.cn/api-reference/userinfo/get-user-info)。

我已确认该 PR 已自测通过，相关截图如下：

![image](https://github.com/user-attachments/assets/fd880eb3-784e-4464-bcab-095b6c7f7853)

