### PR TITLE
feat: add tool choice configuration and update steam handling in Gemini 

### DIFF
--- a/relay/adaptor/gemini/main.go
+++ b/relay/adaptor/gemini/main.go
@@ -116,7 +116,6 @@ func ConvertRequest(textRequest model.GeneralOpenAIRequest) *ChatRequest {
 			}
 		}
 	}
-	shouldAddDummyModelMessage := false
 	for _, message := range textRequest.Messages {
 		content := ChatContent{
 			Role: message.Role,
@@ -154,25 +153,12 @@ func ConvertRequest(textRequest model.GeneralOpenAIRequest) *ChatRequest {
 		if content.Role == "assistant" {
 			content.Role = "model"
 		}
-		// Converting system prompt to prompt from user for the same reason
+		// Converting system prompt to SystemInstructions
 		if content.Role == "system" {
-			content.Role = "user"
-			shouldAddDummyModelMessage = true
+			geminiRequest.SystemInstruction = &content
+			continue
 		}
 		geminiRequest.Contents = append(geminiRequest.Contents, content)
-
-		// If a system message is the last message, we need to add a dummy model message to make gemini happy
-		if shouldAddDummyModelMessage {
-			geminiRequest.Contents = append(geminiRequest.Contents, ChatContent{
-				Role: "model",
-				Parts: []Part{
-					{
-						Text: "Okay",
-					},
-				},
-			})
-			shouldAddDummyModelMessage = false
-		}
 	}
 
 	return &geminiRequest

--- a/relay/adaptor/gemini/model.go
+++ b/relay/adaptor/gemini/model.go
@@ -1,10 +1,12 @@
 package gemini
 
 type ChatRequest struct {
-	Contents         []ChatContent        `json:"contents"`
-	SafetySettings   []ChatSafetySettings `json:"safety_settings,omitempty"`
-	GenerationConfig ChatGenerationConfig `json:"generation_config,omitempty"`
-	Tools            []ChatTools          `json:"tools,omitempty"`
+	Contents          []ChatContent        `json:"contents"`
+	SystemInstruction *ChatContent         `json:"system_instruction,omitempty"`
+	SafetySettings    []ChatSafetySettings `json:"safety_settings,omitempty"`
+	GenerationConfig  ChatGenerationConfig `json:"generation_config,omitempty"`
+	Tools             []ChatTools          `json:"tools,omitempty"`
+	ToolConfig        *ToolConfig          `json:"tool_config,omitempty"`
 }
 
 type EmbeddingRequest struct {
@@ -73,4 +75,13 @@ type ChatGenerationConfig struct {
 	MaxOutputTokens  int      `json:"maxOutputTokens,omitempty"`
 	CandidateCount   int      `json:"candidateCount,omitempty"`
 	StopSequences    []string `json:"stopSequences,omitempty"`
+}
+
+type FunctionCallingConfig struct {
+	Mode                 string   `json:"mode,omitempty"`
+	AllowedFunctionNames []string `json:"allowed_function_names,omitempty"`
+}
+
+type ToolConfig struct {
+	FunctionCallingConfig FunctionCallingConfig `json:"function_calling_config"`
 }


### PR DESCRIPTION
close #1993

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）

**1、增加Gemini对tool_choice的支持。**
顺便修复：thinking模型回答吞字问题；Gemini已经支持system指令，因此可以移除AddDummyModelMessage。
API资料：https://ai.google.dev/gemini-api/docs/system-instructions?hl=zh-cn&lang=rest

system指令：
![image](https://github.com/user-attachments/assets/21da174d-eaec-422b-b723-a7c69509af2a)

tool_choice参数：
![image](https://github.com/user-attachments/assets/3084cbe5-dcda-4c85-bfca-7ee98df6ec66)

thinking模型：
![image](https://github.com/user-attachments/assets/ebc34186-75f0-491f-b482-e4b3c0f17d0d)

