### PR TITLE
fix: remove duplicated model

### DIFF
--- a/relay/adaptor/groq/constants.go
+++ b/relay/adaptor/groq/constants.go
@@ -11,7 +11,6 @@ var ModelList = []string{
 	"llama-3.2-11b-vision-preview",
 	"llama-3.2-1b-preview",
 	"llama-3.2-3b-preview",
-	"llama-3.2-11b-vision-preview",
 	"llama-3.2-90b-text-preview",
 	"llama-3.2-90b-vision-preview",
 	"llama-guard-3-8b",


### PR DESCRIPTION

<img width="279" alt="image" src="https://github.com/user-attachments/assets/22664d26-9e4c-48c2-953c-890186159174" />

groq 的 model 重复了，这个 pr 移除了最新添加的 model

我已确认该 PR 已自测通过
