### PR TITLE
fix: channel test false negative

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -163,4 +163,4 @@ var UserContentRequestProxy = env.String("USER_CONTENT_REQUEST_PROXY", "")
 var UserContentRequestTimeout = env.Int("USER_CONTENT_REQUEST_TIMEOUT", 30)
 
 var EnforceIncludeUsage = env.Bool("ENFORCE_INCLUDE_USAGE", false)
-var TestPrompt = env.String("TEST_PROMPT", "Print your model name exactly and do not output without any other text.")
+var TestPrompt = env.String("TEST_PROMPT", "2 + 2 = ?")


### PR DESCRIPTION
## 问题

channel test 存在很多假阴性问题，即实际上测试失败了，但是页面显示成功。

## 原因

`controller/channel-test.go` 这个文件里，是在 defer 中通过判定 err 是否为空来判断是否失败的，但是代码中很多失败条件下的 err 实际上被覆盖了，导致 defer 中的 err 始终为空，从而导致假阴性。

## 修复

不要使用 `err :=` 来避免覆盖 err。

## 其他修复：test prompt

原来的这个 prompt 会被 azure 的默认 content filter 拦截，所以换了一个。

## 自测

![CleanShot 2025-02-08 at 15 16 29@2x](https://github.com/user-attachments/assets/5d7cd3a1-8800-4a7c-9416-d1f7212cf3a3)
