### PR TITLE
fix: add read/write locks for ModelRatio and GroupRatio to prevent concurrency

### DIFF
--- a/relay/billing/ratio/group.go
+++ b/relay/billing/ratio/group.go
@@ -3,8 +3,10 @@ package ratio
 import (
 	"encoding/json"
 	"github.com/songquanpeng/one-api/common/logger"
+	"sync"
 )
 
+var groupRatioLock sync.RWMutex
 var GroupRatio = map[string]float64{
 	"default": 1,
 	"vip":     1,
@@ -20,11 +22,15 @@ func GroupRatio2JSONString() string {
 }
 
 func UpdateGroupRatioByJSONString(jsonStr string) error {
+	groupRatioLock.Lock()
+	defer groupRatioLock.Unlock()
 	GroupRatio = make(map[string]float64)
 	return json.Unmarshal([]byte(jsonStr), &GroupRatio)
 }
 
 func GetGroupRatio(name string) float64 {
+	groupRatioLock.RLock()
+	defer groupRatioLock.RUnlock()
 	ratio, ok := GroupRatio[name]
 	if !ok {
 		logger.SysError("group ratio not found: " + name)


### PR DESCRIPTION
### Summary

This pull request fixes a critical concurrency issue where multiple goroutines were concurrently reading from and writing to our global maps, causing a runtime panic with the error "concurrent map read and map write." 

### Background

The issue was observed in functions like `GetModelRatio` and others that access global maps such as `ModelRatio`, `GroupRatio`. In Go, built-in maps are not safe for concurrent use, which led to data races and eventual panics under high load.

### Changes Made

- **Added synchronization:**
  - Introduced `sync.RWMutex` locks to protect access to `ModelRatio` and `GroupRatio`.
  - Similarly, added read/write locks for `GroupRatio` to ensure thread-safe operations.
  
- **Updated functions:**
  - Modified functions like `GetModelRatio` and `UpdateModelRatioByJSONString` to use the appropriate read and write locks.
  - Ensured that similar changes are applied to any functions accessing `GroupRatio`.

### Motivation

These changes eliminate the race conditions that were causing runtime errors. By serializing access to these maps, we ensure that reads and writes do not conflict, thus improving the stability and reliability of the system under concurrent load.

### Testing

- Verified that the issue is resolved by simulating high concurrency scenarios.
- Ran the full suite of unit tests to ensure no other functionality is impacted by these changes.

### Impact

This fix is backward-compatible and only affects the internal concurrency management of the global maps. No changes to the external API or functionality are expected.

close #2066

我已确认该 PR 已自测通过