### PR TITLE
feat: support OpenRouter reasoning

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -164,3 +164,6 @@ var UserContentRequestTimeout = env.Int("USER_CONTENT_REQUEST_TIMEOUT", 30)
 
 var EnforceIncludeUsage = env.Bool("ENFORCE_INCLUDE_USAGE", false)
 var TestPrompt = env.String("TEST_PROMPT", "Output only your specific model name with no additional text.")
+
+// OpenrouterProviderSort is used to determine the order of the providers in the openrouter
+var OpenrouterProviderSort = env.String("OPENROUTER_PROVIDER_SORT", "")

--- a/common/conv/any.go
+++ b/common/conv/any.go
@@ -1,6 +1,9 @@
 package conv
 
 func AsString(v any) string {
-	str, _ := v.(string)
-	return str
+	if str, ok := v.(string); ok {
+		return str
+	}
+
+	return ""
 }

--- a/relay/adaptor/openai/adaptor.go
+++ b/relay/adaptor/openai/adaptor.go
@@ -94,12 +94,13 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 	case channeltype.OpenRouter:
 		includeReasoning := true
 		request.IncludeReasoning = &includeReasoning
-		if request.Provider == nil || request.Provider.Sort == "" {
+		if request.Provider == nil || request.Provider.Sort == "" &&
+			config.OpenrouterProviderSort != "" {
 			if request.Provider == nil {
 				request.Provider = &openrouter.RequestProvider{}
 			}
 
-			request.Provider.Sort = "throughput"
+			request.Provider.Sort = config.OpenrouterProviderSort
 		}
 	default:
 	}

--- a/relay/adaptor/openrouter/model.go
+++ b/relay/adaptor/openrouter/model.go
@@ -1,0 +1,22 @@
+package openrouter
+
+// RequestProvider customize how your requests are routed using the provider object
+// in the request body for Chat Completions and Completions.
+//
+// https://openrouter.ai/docs/features/provider-routing
+type RequestProvider struct {
+	// Order is list of provider names to try in order (e.g. ["Anthropic", "OpenAI"]). Default: empty
+	Order []string `json:"order,omitempty"`
+	// AllowFallbacks is whether to allow backup providers when the primary is unavailable. Default: true
+	AllowFallbacks bool `json:"allow_fallbacks,omitempty"`
+	// RequireParameters is only use providers that support all parameters in your request. Default: false
+	RequireParameters bool `json:"require_parameters,omitempty"`
+	// DataCollection is control whether to use providers that may store data ("allow" or "deny"). Default: "allow"
+	DataCollection string `json:"data_collection,omitempty" binding:"omitempty,oneof=allow deny"`
+	// Ignore is list of provider names to skip for this request. Default: empty
+	Ignore []string `json:"ignore,omitempty"`
+	// Quantizations is list of quantization levels to filter by (e.g. ["int4", "int8"]). Default: empty
+	Quantizations []string `json:"quantizations,omitempty"`
+	// Sort is sort providers by price or throughput (e.g. "price" or "throughput"). Default: empty
+	Sort string `json:"sort,omitempty" binding:"omitempty,oneof=price throughput latency"`
+}

--- a/relay/controller/helper.go
+++ b/relay/controller/helper.go
@@ -102,6 +102,9 @@ func postConsumeQuota(ctx context.Context, usage *relaymodel.Usage, meta *meta.M
 	var quota int64
 	completionRatio := billingratio.GetCompletionRatio(textRequest.Model, meta.ChannelType)
 	promptTokens := usage.PromptTokens
+	// It appears that DeepSeek's official service automatically merges ReasoningTokens into CompletionTokens,
+	// but the behavior of third-party providers may differ, so for now we do not add them manually.
+	// completionTokens := usage.CompletionTokens + usage.CompletionTokensDetails.ReasoningTokens
 	completionTokens := usage.CompletionTokens
 	quota = int64(math.Ceil((float64(promptTokens) + float64(completionTokens)*completionRatio) * ratio))
 	if ratio != 0 && quota <= 0 {

--- a/relay/model/general.go
+++ b/relay/model/general.go
@@ -1,5 +1,7 @@
 package model
 
+import "github.com/songquanpeng/one-api/relay/adaptor/openrouter"
+
 type ResponseFormat struct {
 	Type       string      `json:"type,omitempty"`
 	JsonSchema *JSONSchema `json:"json_schema,omitempty"`
@@ -66,6 +68,11 @@ type GeneralOpenAIRequest struct {
 	// Others
 	Instruction string `json:"instruction,omitempty"`
 	NumCtx      int    `json:"num_ctx,omitempty"`
+	// -------------------------------------
+	// Openrouter
+	// -------------------------------------
+	Provider         *openrouter.RequestProvider `json:"provider,omitempty"`
+	IncludeReasoning *bool                       `json:"include_reasoning,omitempty"`
 }
 
 func (r GeneralOpenAIRequest) ParseInput() []string {

--- a/relay/model/message.go
+++ b/relay/model/message.go
@@ -1,12 +1,35 @@
 package model
 
 type Message struct {
-	Role             string  `json:"role,omitempty"`
-	Content          any     `json:"content,omitempty"`
-	ReasoningContent any     `json:"reasoning_content,omitempty"`
-	Name             *string `json:"name,omitempty"`
-	ToolCalls        []Tool  `json:"tool_calls,omitempty"`
-	ToolCallId       string  `json:"tool_call_id,omitempty"`
+	Role string `json:"role,omitempty"`
+	// Content is a string or a list of objects
+	Content    any           `json:"content,omitempty"`
+	Name       *string       `json:"name,omitempty"`
+	ToolCalls  []Tool        `json:"tool_calls,omitempty"`
+	ToolCallId string        `json:"tool_call_id,omitempty"`
+	Audio      *messageAudio `json:"audio,omitempty"`
+	// -------------------------------------
+	// Deepseek 专有的一些字段
+	// https://api-docs.deepseek.com/api/create-chat-completion
+	// -------------------------------------
+	// Prefix forces the model to begin its answer with the supplied prefix in the assistant message.
+	// To enable this feature, set base_url to "https://api.deepseek.com/beta".
+	Prefix *bool `json:"prefix,omitempty"` // ReasoningContent is Used for the deepseek-reasoner model in the Chat
+	// Prefix Completion feature as the input for the CoT in the last assistant message.
+	// When using this feature, the prefix parameter must be set to true.
+	ReasoningContent *string `json:"reasoning_content,omitempty"`
+	// -------------------------------------
+	// Openrouter
+	// -------------------------------------
+	Reasoning *string `json:"reasoning,omitempty"`
+	Refusal   *bool   `json:"refusal,omitempty"`
+}
+
+type messageAudio struct {
+	Id         string `json:"id"`
+	Data       string `json:"data,omitempty"`
+	ExpiredAt  int    `json:"expired_at,omitempty"`
+	Transcript string `json:"transcript,omitempty"`
 }
 
 func (m Message) IsStringContent() bool {

--- a/relay/model/misc.go
+++ b/relay/model/misc.go
@@ -4,14 +4,12 @@ type Usage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
-
-	CompletionTokensDetails *CompletionTokensDetails `json:"completion_tokens_details,omitempty"`
-}
-
-type CompletionTokensDetails struct {
-	ReasoningTokens          int `json:"reasoning_tokens"`
-	AcceptedPredictionTokens int `json:"accepted_prediction_tokens"`
-	RejectedPredictionTokens int `json:"rejected_prediction_tokens"`
+	// PromptTokensDetails may be empty for some models
+	PromptTokensDetails *usagePromptTokensDetails `gorm:"-" json:"prompt_tokens_details,omitempty"`
+	// CompletionTokensDetails may be empty for some models
+	CompletionTokensDetails *usageCompletionTokensDetails `gorm:"-" json:"completion_tokens_details,omitempty"`
+	ServiceTier             string                        `gorm:"-" json:"service_tier,omitempty"`
+	SystemFingerprint       string                        `gorm:"-" json:"system_fingerprint,omitempty"`
 }
 
 type Error struct {
@@ -24,4 +22,21 @@ type Error struct {
 type ErrorWithStatusCode struct {
 	Error
 	StatusCode int `json:"status_code"`
+}
+
+type usagePromptTokensDetails struct {
+	CachedTokens int `json:"cached_tokens"`
+	AudioTokens  int `json:"audio_tokens"`
+	// TextTokens could be zero for pure text chats
+	TextTokens  int `json:"text_tokens"`
+	ImageTokens int `json:"image_tokens"`
+}
+
+type usageCompletionTokensDetails struct {
+	ReasoningTokens          int `json:"reasoning_tokens"`
+	AudioTokens              int `json:"audio_tokens"`
+	AcceptedPredictionTokens int `json:"accepted_prediction_tokens"`
+	RejectedPredictionTokens int `json:"rejected_prediction_tokens"`
+	// TextTokens could be zero for pure text chats
+	TextTokens int `json:"text_tokens"`
 }


### PR DESCRIPTION
## 解决的问题

目前 deepseek-r1 的 reasoning 返回格式有三个流派：

1. 【已支持】deepseek 官方，使用 `reasoning_content`
2. 【已支持】第三方供应商使用 `<think></think>` 包裹，放置在 content 中
3. 【不支持】OpenRouter 使用自定义的 `reasoning` 字段

该 PR 就是支持了 openrouter 的格式，在请求时自动添加 `include_reasoning`。

ref: https://openrouter.ai/docs/api-reference/parameters#include-reasoning

可以试用 https://github.com/Laisky/one-api

## 自测

![CleanShot 2025-02-19 at 09 25 18@2x](https://github.com/user-attachments/assets/42148e97-6f7a-42ba-a272-4720aa5fbaa6)
