### PR TITLE
feat: add FIM completions support to alibailian

### DIFF
--- a/relay/adaptor/alibailian/main.go
+++ b/relay/adaptor/alibailian/main.go
@@ -9,6 +9,8 @@ import (
 
 func GetRequestURL(meta *meta.Meta) (string, error) {
 	switch meta.Mode {
+	case relaymode.Completions:
+		return fmt.Sprintf("%s/compatible-mode/v1/completions", meta.BaseURL), nil
 	case relaymode.ChatCompletions:
 		return fmt.Sprintf("%s/compatible-mode/v1/chat/completions", meta.BaseURL), nil
 	case relaymode.Embeddings:


### PR DESCRIPTION
Related #1522 #1795

百炼本身是支持 FIM (`/v1/completions`) 接口的，但取决于具体模型是否兼容。已知至少 `qwen-coder-turbo` 和 `qwen2.5-coder-7b-instruct` 是能支持的，截图如下：

![image](https://github.com/user-attachments/assets/07b8ac80-855a-4d21-87af-3dd2ba3e5fa4)

> Edit: 截图意外泄露API-Key了，已经回收该Key😂

测试命令：

```bash
curl -X POST "https://dashscope.aliyuncs.com/compatible-mode/v1/completions" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <your-token>" \
  -d '{
        "model": "qwen-coder-turbo",
        "prompt": "def fib(a):",
        "suffix": "    return fib(a-1) + fib(a-2)",
        "max_tokens": 128
      }'
```

改动很小，一共两行代码一眼就能看完，望尽快合入。