### PR TITLE
添加 Azure 渠道对 Azure AI 推理终结点链接的支持

### DIFF
--- a/relay/adaptor/openai/adaptor.go
+++ b/relay/adaptor/openai/adaptor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -43,7 +44,14 @@ func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
 		// https://learn.microsoft.com/en-us/azure/cognitive-services/openai/chatgpt-quickstart?pivots=rest-api&tabs=command-line#rest-api
 		requestURL := strings.Split(meta.RequestURLPath, "?")[0]
 		requestURL = fmt.Sprintf("%s?api-version=%s", requestURL, meta.Config.APIVersion)
+
 		task := strings.TrimPrefix(requestURL, "/v1/")
+
+		// Azure AI model inference API `https://<resource-name>.services.ai.azure.com/models`
+		if path.Base(meta.BaseURL) == "models" {
+			return GetFullRequestURL(meta.BaseURL, "/" + task, meta.ChannelType), nil
+		}
+
 		model_ := meta.ActualModelName
 		model_ = strings.Replace(model_, ".", "", -1)
 		//https://github.com/songquanpeng/one-api/issues/1191


### PR DESCRIPTION
添加 Azure 渠道对 Azure AI 推理终结点链接的支持，一些非 OpenAI 的模型，例如 DeepSeek-R1 ... 官方的 Azure AI 推理服务 API 是兼容 OpenAI 的，改动不大，作者考虑下做下兼容呗.

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
![image](https://github.com/user-attachments/assets/78d30bdf-fb43-47bb-8ca6-0d3539c93502)
![image](https://github.com/user-attachments/assets/de39c639-5c62-4c05-9d91-45c892d554ee)
![image](https://github.com/user-attachments/assets/1e810e4c-78dd-44d8-8c8a-1dcf5d3f7fad)
![image](https://github.com/user-attachments/assets/9ceece0c-a051-484f-8a5c-535a60f34267)
