### PR TITLE
fix: resolve "bufio.Scanner: token too long" error by increasing buff…

### DIFF
--- a/relay/adaptor/openai/main.go
+++ b/relay/adaptor/openai/main.go
@@ -27,6 +27,8 @@ const (
 func StreamHandler(c *gin.Context, resp *http.Response, relayMode int) (*model.ErrorWithStatusCode, string, *model.Usage) {
 	responseText := ""
 	scanner := bufio.NewScanner(resp.Body)
+	buffer := make([]byte, 256*1024)
+	scanner.Buffer(buffer, len(buffer))
 	scanner.Split(bufio.ScanLines)
 	var usage *model.Usage
 


### PR DESCRIPTION
close #1982 

---
在请求包含了如联网搜索、知识库查询等接口时，在流式接口的第一行往往会带上大量的references内容。

如请求火山引擎进行天气查询时，首行返回的文本 ~75kb
![image](https://github.com/user-attachments/assets/aae1460b-ceac-40dd-ad16-7d1becdb92f3)
超过缓冲区大小
![image](https://github.com/user-attachments/assets/f109919a-8021-4e80-863d-b7cce3c8391e)

默认bufio.Scanner的缓冲区只有64kb，适当调整至256kb，兼容该场景。

---
我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/b20eb583-8fa8-4828-9b49-a47f4f8a34fe)

