### PR TITLE
feat: Enhance VolcEngine channel support with bot model

### DIFF
--- a/relay/adaptor/doubao/main.go
+++ b/relay/adaptor/doubao/main.go
@@ -9,6 +9,9 @@ import (
 func GetRequestURL(meta *meta.Meta) (string, error) {
 	switch meta.Mode {
 	case relaymode.ChatCompletions:
+		if strings.HasPrefix(meta.ActualModelName, "bot") {
+			return fmt.Sprintf("%s/api/v3/bots/chat/completions", meta.BaseURL), nil
+		}
 		return fmt.Sprintf("%s/api/v3/chat/completions", meta.BaseURL), nil
 	case relaymode.Embeddings:
 		return fmt.Sprintf("%s/api/v3/embeddings", meta.BaseURL), nil

--- a/relay/adaptor/openai/main.go
+++ b/relay/adaptor/openai/main.go
@@ -34,7 +34,7 @@ func StreamHandler(c *gin.Context, resp *http.Response, relayMode int) (*model.E
 
 	doneRendered := false
 	for scanner.Scan() {
-		data := scanner.Text()
+		data := NormalizeDataLine(scanner.Text())
 		if len(data) < dataPrefixLength { // ignore blank line or wrong format
 			continue
 		}

--- a/relay/adaptor/openai/util.go
+++ b/relay/adaptor/openai/util.go
@@ -21,3 +21,11 @@ func ErrorWrapper(err error, code string, statusCode int) *model.ErrorWithStatus
 		StatusCode: statusCode,
 	}
 }
+
+func NormalizeDataLine(data string) string {
+	if strings.HasPrefix(data, "data:") {
+		content := strings.TrimLeft(data[len("data:"):], " ")
+		return "data: " + content
+	}
+	return data
+}


### PR DESCRIPTION
close #2109
close #1763 

---
适配火山引擎（火山方舟）中应用的接入，目前网络上使用火山引擎的应用来使用DeepSeek的联网功能的教程比较多，建议完成该场景的适配。

1. 调整OpenAI方式下，对响应格式的优化，火山引擎的应用返回的报文中，“data:”后不存在空格，统一对响应行进行预处理；
2. 增加火山引擎的RequestURL的路由，在火山引擎的Chann中，针对ActualModelName以“bot”开头的模型，返回“/api/v3/bots/chat/completions”的路径；

---
我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/03b4f92d-471d-46b5-81ac-39a4186a9e77)
![image](https://github.com/user-attachments/assets/b6e521a0-4f3f-4d9d-9248-c80a53eadc00)

