### PR TITLE
feat: support claude thinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ graph LR
    + 例子：`NODE_TYPE=slave`
 9. `CHANNEL_UPDATE_FREQUENCY`：设置之后将定期更新渠道余额，单位为分钟，未设置则不进行更新。
    + 例子：`CHANNEL_UPDATE_FREQUENCY=1440`
-10. `CHANNEL_TEST_FREQUENCY`：设置之后将定期检查渠道，单位为分钟，未设置则不进行检查。 
+10. `CHANNEL_TEST_FREQUENCY`：设置之后将定期检查渠道，单位为分钟，未设置则不进行检查。
    +例子：`CHANNEL_TEST_FREQUENCY=1440`
 11. `POLLING_INTERVAL`：批量更新渠道余额以及测试可用性时的请求间隔，单位为秒，默认无间隔。
     + 例子：`POLLING_INTERVAL=5`

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -164,3 +164,6 @@ var UserContentRequestTimeout = env.Int("USER_CONTENT_REQUEST_TIMEOUT", 30)
 
 var EnforceIncludeUsage = env.Bool("ENFORCE_INCLUDE_USAGE", false)
 var TestPrompt = env.String("TEST_PROMPT", "Output only your specific model name with no additional text.")
+
+// OpenrouterProviderSort is used to determine the order of the providers in the openrouter
+var OpenrouterProviderSort = env.String("OPENROUTER_PROVIDER_SORT", "")

--- a/common/conv/any.go
+++ b/common/conv/any.go
@@ -1,6 +1,9 @@
 package conv
 
 func AsString(v any) string {
-	str, _ := v.(string)
-	return str
+	if str, ok := v.(string); ok {
+		return str
+	}
+
+	return ""
 }

--- a/relay/adaptor/anthropic/adaptor.go
+++ b/relay/adaptor/anthropic/adaptor.go
@@ -36,8 +36,8 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Request, meta *me
 
 	// https://x.com/alexalbert__/status/1812921642143900036
 	// claude-3-5-sonnet can support 8k context
-	if strings.HasPrefix(meta.ActualModelName, "claude-3-5-sonnet") {
-		req.Header.Set("anthropic-beta", "max-tokens-3-5-sonnet-2024-07-15")
+	if strings.HasPrefix(meta.ActualModelName, "claude-3-7-sonnet") {
+		req.Header.Set("anthropic-beta", "output-128k-2025-02-19")
 	}
 
 	return nil

--- a/relay/adaptor/anthropic/constants.go
+++ b/relay/adaptor/anthropic/constants.go
@@ -3,11 +3,13 @@ package anthropic
 var ModelList = []string{
 	"claude-instant-1.2", "claude-2.0", "claude-2.1",
 	"claude-3-haiku-20240307",
-	"claude-3-5-haiku-20241022",
 	"claude-3-5-haiku-latest",
+	"claude-3-5-haiku-20241022",
 	"claude-3-sonnet-20240229",
 	"claude-3-opus-20240229",
+	"claude-3-5-sonnet-latest",
 	"claude-3-5-sonnet-20240620",
 	"claude-3-5-sonnet-20241022",
-	"claude-3-5-sonnet-latest",
+	"claude-3-7-sonnet-latest",
+	"claude-3-7-sonnet-20250219",
 }

--- a/relay/adaptor/anthropic/main.go
+++ b/relay/adaptor/anthropic/main.go
@@ -4,10 +4,11 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/songquanpeng/one-api/common/render"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/songquanpeng/one-api/common/render"
 
 	"github.com/gin-gonic/gin"
 	"github.com/songquanpeng/one-api/common"
@@ -61,6 +62,7 @@ func ConvertRequest(textRequest model.GeneralOpenAIRequest) *Request {
 		TopK:        textRequest.TopK,
 		Stream:      textRequest.Stream,
 		Tools:       claudeTools,
+		Thinking:    textRequest.Thinking,
 	}
 	if len(claudeTools) > 0 {
 		claudeToolChoice := struct {
@@ -149,6 +151,7 @@ func ConvertRequest(textRequest model.GeneralOpenAIRequest) *Request {
 func StreamResponseClaude2OpenAI(claudeResponse *StreamResponse) (*openai.ChatCompletionsStreamResponse, *Response) {
 	var response *Response
 	var responseText string
+	var reasoningText string
 	var stopReason string
 	tools := make([]model.Tool, 0)
 
@@ -158,6 +161,10 @@ func StreamResponseClaude2OpenAI(claudeResponse *StreamResponse) (*openai.ChatCo
 	case "content_block_start":
 		if claudeResponse.ContentBlock != nil {
 			responseText = claudeResponse.ContentBlock.Text
+			if claudeResponse.ContentBlock.Thinking != nil {
+				reasoningText = *claudeResponse.ContentBlock.Thinking
+			}
+
 			if claudeResponse.ContentBlock.Type == "tool_use" {
 				tools = append(tools, model.Tool{
 					Id:   claudeResponse.ContentBlock.Id,
@@ -172,6 +179,10 @@ func StreamResponseClaude2OpenAI(claudeResponse *StreamResponse) (*openai.ChatCo
 	case "content_block_delta":
 		if claudeResponse.Delta != nil {
 			responseText = claudeResponse.Delta.Text
+			if claudeResponse.Delta.Thinking != nil {
+				reasoningText = *claudeResponse.Delta.Thinking
+			}
+
 			if claudeResponse.Delta.Type == "input_json_delta" {
 				tools = append(tools, model.Tool{
 					Function: model.Function{
@@ -189,9 +200,20 @@ func StreamResponseClaude2OpenAI(claudeResponse *StreamResponse) (*openai.ChatCo
 		if claudeResponse.Delta != nil && claudeResponse.Delta.StopReason != nil {
 			stopReason = *claudeResponse.Delta.StopReason
 		}
+	case "thinking_delta":
+		if claudeResponse.Delta != nil && claudeResponse.Delta.Thinking != nil {
+			reasoningText = *claudeResponse.Delta.Thinking
+		}
+	case "ping",
+		"message_stop",
+		"content_block_stop":
+	default:
+		logger.SysErrorf("unknown stream response type %q", claudeResponse.Type)
 	}
+
 	var choice openai.ChatCompletionsStreamResponseChoice
 	choice.Delta.Content = responseText
+	choice.Delta.Reasoning = &reasoningText
 	if len(tools) > 0 {
 		choice.Delta.Content = nil // compatible with other OpenAI derivative applications, like LobeOpenAICompatibleFactory ...
 		choice.Delta.ToolCalls = tools
@@ -209,11 +231,15 @@ func StreamResponseClaude2OpenAI(claudeResponse *StreamResponse) (*openai.ChatCo
 
 func ResponseClaude2OpenAI(claudeResponse *Response) *openai.TextResponse {
 	var responseText string
-	if len(claudeResponse.Content) > 0 {
-		responseText = claudeResponse.Content[0].Text
-	}
+	var reasoningText string
+
 	tools := make([]model.Tool, 0)
 	for _, v := range claudeResponse.Content {
+		reasoningText += v.Text
+		if v.Thinking != nil {
+			reasoningText += *v.Thinking
+		}
+
 		if v.Type == "tool_use" {
 			args, _ := json.Marshal(v.Input)
 			tools = append(tools, model.Tool{
@@ -231,6 +257,7 @@ func ResponseClaude2OpenAI(claudeResponse *Response) *openai.TextResponse {
 		Message: model.Message{
 			Role:      "assistant",
 			Content:   responseText,
+			Reasoning: &reasoningText,
 			Name:      nil,
 			ToolCalls: tools,
 		},
@@ -276,6 +303,8 @@ func StreamHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusC
 		}
 		data = strings.TrimPrefix(data, "data:")
 		data = strings.TrimSpace(data)
+
+		logger.Debugf(c.Request.Context(), "stream <- %q\n", data)
 
 		var claudeResponse StreamResponse
 		err := json.Unmarshal([]byte(data), &claudeResponse)
@@ -344,6 +373,7 @@ func Handler(c *gin.Context, resp *http.Response, promptTokens int, modelName st
 	if err != nil {
 		return openai.ErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), nil
 	}
+
 	var claudeResponse Response
 	err = json.Unmarshal(responseBody, &claudeResponse)
 	if err != nil {

--- a/relay/adaptor/anthropic/main.go
+++ b/relay/adaptor/anthropic/main.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -235,9 +236,17 @@ func ResponseClaude2OpenAI(claudeResponse *Response) *openai.TextResponse {
 
 	tools := make([]model.Tool, 0)
 	for _, v := range claudeResponse.Content {
-		reasoningText += v.Text
-		if v.Thinking != nil {
-			reasoningText += *v.Thinking
+		switch v.Type {
+		case "thinking":
+			if v.Thinking != nil {
+				reasoningText += *v.Thinking
+			} else {
+				logger.Errorf(context.Background(), "thinking is nil in response")
+			}
+		case "text":
+			responseText += v.Text
+		default:
+			logger.Warnf(context.Background(), "unknown response type %q", v.Type)
 		}
 
 		if v.Type == "tool_use" {
@@ -252,6 +261,7 @@ func ResponseClaude2OpenAI(claudeResponse *Response) *openai.TextResponse {
 			})
 		}
 	}
+
 	choice := openai.TextResponseChoice{
 		Index: 0,
 		Message: model.Message{
@@ -373,6 +383,8 @@ func Handler(c *gin.Context, resp *http.Response, promptTokens int, modelName st
 	if err != nil {
 		return openai.ErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), nil
 	}
+
+	logger.Debugf(c.Request.Context(), "response <- %s\n", string(responseBody))
 
 	var claudeResponse Response
 	err = json.Unmarshal(responseBody, &claudeResponse)

--- a/relay/adaptor/anthropic/model.go
+++ b/relay/adaptor/anthropic/model.go
@@ -1,5 +1,7 @@
 package anthropic
 
+import "github.com/songquanpeng/one-api/relay/model"
+
 // https://docs.anthropic.com/claude/reference/messages_post
 
 type Metadata struct {
@@ -22,6 +24,9 @@ type Content struct {
 	Input     any    `json:"input,omitempty"`
 	Content   string `json:"content,omitempty"`
 	ToolUseId string `json:"tool_use_id,omitempty"`
+	// https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#implementing-extended-thinking
+	Thinking  *string `json:"thinking,omitempty"`
+	Signature *string `json:"signature,omitempty"`
 }
 
 type Message struct {
@@ -54,6 +59,7 @@ type Request struct {
 	Tools         []Tool    `json:"tools,omitempty"`
 	ToolChoice    any       `json:"tool_choice,omitempty"`
 	//Metadata    `json:"metadata,omitempty"`
+	Thinking *model.Thinking `json:"thinking,omitempty"`
 }
 
 type Usage struct {
@@ -84,6 +90,8 @@ type Delta struct {
 	PartialJson  string  `json:"partial_json,omitempty"`
 	StopReason   *string `json:"stop_reason"`
 	StopSequence *string `json:"stop_sequence"`
+	Thinking     *string `json:"thinking,omitempty"`
+	Signature    *string `json:"signature,omitempty"`
 }
 
 type StreamResponse struct {

--- a/relay/adaptor/aws/claude/main.go
+++ b/relay/adaptor/aws/claude/main.go
@@ -36,6 +36,8 @@ var AwsModelIDMap = map[string]string{
 	"claude-3-5-sonnet-20241022": "anthropic.claude-3-5-sonnet-20241022-v2:0",
 	"claude-3-5-sonnet-latest":   "anthropic.claude-3-5-sonnet-20241022-v2:0",
 	"claude-3-5-haiku-20241022":  "anthropic.claude-3-5-haiku-20241022-v1:0",
+	"claude-3-7-sonnet-latest":   "anthropic.claude-3-7-sonnet-20250219-v1:0",
+	"claude-3-7-sonnet-20250219": "anthropic.claude-3-7-sonnet-20250219-v1:0",
 }
 
 func awsModelID(requestModel string) (string, error) {

--- a/relay/adaptor/openai/adaptor.go
+++ b/relay/adaptor/openai/adaptor.go
@@ -94,12 +94,13 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 	case channeltype.OpenRouter:
 		includeReasoning := true
 		request.IncludeReasoning = &includeReasoning
-		if request.Provider == nil || request.Provider.Sort == "" {
+		if request.Provider == nil || request.Provider.Sort == "" &&
+			config.OpenrouterProviderSort != "" {
 			if request.Provider == nil {
 				request.Provider = &openrouter.RequestProvider{}
 			}
 
-			request.Provider.Sort = "throughput"
+			request.Provider.Sort = config.OpenrouterProviderSort
 		}
 	default:
 	}

--- a/relay/adaptor/openrouter/model.go
+++ b/relay/adaptor/openrouter/model.go
@@ -1,0 +1,22 @@
+package openrouter
+
+// RequestProvider customize how your requests are routed using the provider object
+// in the request body for Chat Completions and Completions.
+//
+// https://openrouter.ai/docs/features/provider-routing
+type RequestProvider struct {
+	// Order is list of provider names to try in order (e.g. ["Anthropic", "OpenAI"]). Default: empty
+	Order []string `json:"order,omitempty"`
+	// AllowFallbacks is whether to allow backup providers when the primary is unavailable. Default: true
+	AllowFallbacks bool `json:"allow_fallbacks,omitempty"`
+	// RequireParameters is only use providers that support all parameters in your request. Default: false
+	RequireParameters bool `json:"require_parameters,omitempty"`
+	// DataCollection is control whether to use providers that may store data ("allow" or "deny"). Default: "allow"
+	DataCollection string `json:"data_collection,omitempty" binding:"omitempty,oneof=allow deny"`
+	// Ignore is list of provider names to skip for this request. Default: empty
+	Ignore []string `json:"ignore,omitempty"`
+	// Quantizations is list of quantization levels to filter by (e.g. ["int4", "int8"]). Default: empty
+	Quantizations []string `json:"quantizations,omitempty"`
+	// Sort is sort providers by price or throughput (e.g. "price" or "throughput"). Default: empty
+	Sort string `json:"sort,omitempty" binding:"omitempty,oneof=price throughput latency"`
+}

--- a/relay/adaptor/vertexai/claude/adapter.go
+++ b/relay/adaptor/vertexai/claude/adapter.go
@@ -19,6 +19,7 @@ var ModelList = []string{
 	"claude-3-5-sonnet@20240620",
 	"claude-3-5-sonnet-v2@20241022",
 	"claude-3-5-haiku@20241022",
+	"claude-3-7-sonnet@20250219",
 }
 
 const anthropicVersion = "vertex-2023-10-16"

--- a/relay/billing/ratio/model.go
+++ b/relay/billing/ratio/model.go
@@ -98,6 +98,8 @@ var ModelRatio = map[string]float64{
 	"claude-3-5-sonnet-20240620": 3.0 / 1000 * USD,
 	"claude-3-5-sonnet-20241022": 3.0 / 1000 * USD,
 	"claude-3-5-sonnet-latest":   3.0 / 1000 * USD,
+	"claude-3-7-sonnet-20250219": 3.0 / 1000 * USD,
+	"claude-3-7-sonnet-latest":   3.0 / 1000 * USD,
 	"claude-3-opus-20240229":     15.0 / 1000 * USD,
 	// https://cloud.baidu.com/doc/WENXINWORKSHOP/s/hlrk4akp7
 	"ERNIE-4.0-8K":       0.120 * RMB,

--- a/relay/controller/helper.go
+++ b/relay/controller/helper.go
@@ -102,6 +102,9 @@ func postConsumeQuota(ctx context.Context, usage *relaymodel.Usage, meta *meta.M
 	var quota int64
 	completionRatio := billingratio.GetCompletionRatio(textRequest.Model, meta.ChannelType)
 	promptTokens := usage.PromptTokens
+	// It appears that DeepSeek's official service automatically merges ReasoningTokens into CompletionTokens,
+	// but the behavior of third-party providers may differ, so for now we do not add them manually.
+	// completionTokens := usage.CompletionTokens + usage.CompletionTokensDetails.ReasoningTokens
 	completionTokens := usage.CompletionTokens
 	quota = int64(math.Ceil((float64(promptTokens) + float64(completionTokens)*completionRatio) * ratio))
 	if ratio != 0 && quota <= 0 {

--- a/relay/model/general.go
+++ b/relay/model/general.go
@@ -1,5 +1,7 @@
 package model
 
+import "github.com/songquanpeng/one-api/relay/adaptor/openrouter"
+
 type ResponseFormat struct {
 	Type       string      `json:"type,omitempty"`
 	JsonSchema *JSONSchema `json:"json_schema,omitempty"`
@@ -66,6 +68,11 @@ type GeneralOpenAIRequest struct {
 	// Others
 	Instruction string `json:"instruction,omitempty"`
 	NumCtx      int    `json:"num_ctx,omitempty"`
+	// -------------------------------------
+	// Openrouter
+	// -------------------------------------
+	Provider         *openrouter.RequestProvider `json:"provider,omitempty"`
+	IncludeReasoning *bool                       `json:"include_reasoning,omitempty"`
 }
 
 func (r GeneralOpenAIRequest) ParseInput() []string {

--- a/relay/model/general.go
+++ b/relay/model/general.go
@@ -73,6 +73,16 @@ type GeneralOpenAIRequest struct {
 	// -------------------------------------
 	Provider         *openrouter.RequestProvider `json:"provider,omitempty"`
 	IncludeReasoning *bool                       `json:"include_reasoning,omitempty"`
+	// -------------------------------------
+	// Anthropic
+	// -------------------------------------
+	Thinking *Thinking `json:"thinking,omitempty"`
+}
+
+// https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#implementing-extended-thinking
+type Thinking struct {
+	Type         string `json:"type"`
+	BudgetTokens int    `json:"budget_tokens" binding:"omitempty,min=1024"`
 }
 
 func (r GeneralOpenAIRequest) ParseInput() []string {

--- a/relay/model/message.go
+++ b/relay/model/message.go
@@ -1,12 +1,35 @@
 package model
 
 type Message struct {
-	Role             string  `json:"role,omitempty"`
-	Content          any     `json:"content,omitempty"`
-	ReasoningContent any     `json:"reasoning_content,omitempty"`
-	Name             *string `json:"name,omitempty"`
-	ToolCalls        []Tool  `json:"tool_calls,omitempty"`
-	ToolCallId       string  `json:"tool_call_id,omitempty"`
+	Role string `json:"role,omitempty"`
+	// Content is a string or a list of objects
+	Content    any           `json:"content,omitempty"`
+	Name       *string       `json:"name,omitempty"`
+	ToolCalls  []Tool        `json:"tool_calls,omitempty"`
+	ToolCallId string        `json:"tool_call_id,omitempty"`
+	Audio      *messageAudio `json:"audio,omitempty"`
+	// -------------------------------------
+	// Deepseek 专有的一些字段
+	// https://api-docs.deepseek.com/api/create-chat-completion
+	// -------------------------------------
+	// Prefix forces the model to begin its answer with the supplied prefix in the assistant message.
+	// To enable this feature, set base_url to "https://api.deepseek.com/beta".
+	Prefix *bool `json:"prefix,omitempty"` // ReasoningContent is Used for the deepseek-reasoner model in the Chat
+	// Prefix Completion feature as the input for the CoT in the last assistant message.
+	// When using this feature, the prefix parameter must be set to true.
+	ReasoningContent *string `json:"reasoning_content,omitempty"`
+	// -------------------------------------
+	// Openrouter
+	// -------------------------------------
+	Reasoning *string `json:"reasoning,omitempty"`
+	Refusal   *bool   `json:"refusal,omitempty"`
+}
+
+type messageAudio struct {
+	Id         string `json:"id"`
+	Data       string `json:"data,omitempty"`
+	ExpiredAt  int    `json:"expired_at,omitempty"`
+	Transcript string `json:"transcript,omitempty"`
 }
 
 func (m Message) IsStringContent() bool {

--- a/relay/model/misc.go
+++ b/relay/model/misc.go
@@ -4,14 +4,12 @@ type Usage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
-
-	CompletionTokensDetails *CompletionTokensDetails `json:"completion_tokens_details,omitempty"`
-}
-
-type CompletionTokensDetails struct {
-	ReasoningTokens          int `json:"reasoning_tokens"`
-	AcceptedPredictionTokens int `json:"accepted_prediction_tokens"`
-	RejectedPredictionTokens int `json:"rejected_prediction_tokens"`
+	// PromptTokensDetails may be empty for some models
+	PromptTokensDetails *usagePromptTokensDetails `gorm:"-" json:"prompt_tokens_details,omitempty"`
+	// CompletionTokensDetails may be empty for some models
+	CompletionTokensDetails *usageCompletionTokensDetails `gorm:"-" json:"completion_tokens_details,omitempty"`
+	ServiceTier             string                        `gorm:"-" json:"service_tier,omitempty"`
+	SystemFingerprint       string                        `gorm:"-" json:"system_fingerprint,omitempty"`
 }
 
 type Error struct {
@@ -24,4 +22,21 @@ type Error struct {
 type ErrorWithStatusCode struct {
 	Error
 	StatusCode int `json:"status_code"`
+}
+
+type usagePromptTokensDetails struct {
+	CachedTokens int `json:"cached_tokens"`
+	AudioTokens  int `json:"audio_tokens"`
+	// TextTokens could be zero for pure text chats
+	TextTokens  int `json:"text_tokens"`
+	ImageTokens int `json:"image_tokens"`
+}
+
+type usageCompletionTokensDetails struct {
+	ReasoningTokens          int `json:"reasoning_tokens"`
+	AudioTokens              int `json:"audio_tokens"`
+	AcceptedPredictionTokens int `json:"accepted_prediction_tokens"`
+	RejectedPredictionTokens int `json:"rejected_prediction_tokens"`
+	// TextTokens could be zero for pure text chats
+	TextTokens int `json:"text_tokens"`
 }


### PR DESCRIPTION
## 说明

支持 claude 的 thinking 模式，因为 OpenAI 没有相关接口，所以采用 OpenRouter 的格式返回。

https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#implementing-extended-thinking

依赖下列两个 PR：

* https://github.com/songquanpeng/one-api/pull/2143
* https://github.com/songquanpeng/one-api/pull/2108

可以试用 https://github.com/Laisky/one-api

## 自测

### Stream

![CleanShot 2025-02-25 at 10 55 49@2x](https://github.com/user-attachments/assets/c8cb10d8-7641-4682-9e18-9c5cac029efe)

### Non-Stream

![claude-thinking-non-stream](https://github.com/user-attachments/assets/aa83e5f3-225b-4c37-b962-7de67c5d2c23)

