### PR TITLE
docs: fix Markdown list in the English README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -315,7 +315,7 @@ If the channel ID is not provided, load balancing will be used to distribute the
 * [FastGPT](https://github.com/labring/FastGPT): Knowledge question answering system based on the LLM
 * [VChart](https://github.com/VisActor/VChart):  More than just a cross-platform charting library, but also an expressive data storyteller.
 * [VMind](https://github.com/VisActor/VMind):  Not just automatic, but also fantastic. Open-source solution for intelligent visualization.
-* * [CherryStudio](https://github.com/CherryHQ/cherry-studio):  A cross-platform AI client that integrates multiple service providers and supports local knowledge base management.
+* [CherryStudio](https://github.com/CherryHQ/cherry-studio):  A cross-platform AI client that integrates multiple service providers and supports local knowledge base management.
 
 ## Note
 This project is an open-source project. Please use it in compliance with OpenAI's [Terms of Use](https://openai.com/policies/terms-of-use) and **applicable laws and regulations**. It must not be used for illegal purposes.


### PR DESCRIPTION
简单修复一下英文 Readme 列表样式问题

我已确认该 PR 已自测通过，相关截图如下：

![image](https://github.com/user-attachments/assets/54138871-bf34-43a9-8ff0-1c780f4a086f)
![image](https://github.com/user-attachments/assets/2836830a-46aa-46c8-9ce5-db89cafe4d04)
