### PR TITLE
fix：时区原因导致总览页面报错

### DIFF
--- a/web/default/src/pages/Dashboard/index.js
+++ b/web/default/src/pages/Dashboard/index.js
@@ -131,7 +131,11 @@ const Dashboard = () => {
 
     // 生成所有日期
     for (let d = new Date(minDate); d <= maxDate; d.setDate(d.getDate() + 1)) {
-      const dateStr = d.toISOString().split('T')[0];
+      // 手动提取年月日，确保使用本地时区
+      const year = d.getFullYear();
+      const month = String(d.getMonth() + 1).padStart(2, '0'); // 月份从 0 开始，需要 +1
+      const day = String(d.getDate()).padStart(2, '0');
+      const dateStr = `${year}-${month}-${day}`;
       dailyData[dateStr] = {
         date: dateStr,
         requests: 0,
@@ -142,9 +146,12 @@ const Dashboard = () => {
 
     // 填充实际数据
     data.forEach((item) => {
-      dailyData[item.Day].requests += item.RequestCount;
-      dailyData[item.Day].quota += item.Quota / 1000000;
-      dailyData[item.Day].tokens += item.PromptTokens + item.CompletionTokens;
+      const data = dailyData[item.Day];
+      if (data) {
+        data.requests += item.RequestCount;
+        data.quota += item.Quota / 1000000;
+        data.tokens += item.PromptTokens + item.CompletionTokens;
+      }
     });
 
     return Object.values(dailyData).sort((a, b) =>
@@ -173,7 +180,11 @@ const Dashboard = () => {
 
     // 生成所有日期
     for (let d = new Date(minDate); d <= maxDate; d.setDate(d.getDate() + 1)) {
-      const dateStr = d.toISOString().split('T')[0];
+       // 手动提取年月日，确保使用 本地时区
+       const year = d.getFullYear();
+       const month = String(d.getMonth() + 1).padStart(2, '0'); // 月份从 0 开始，需要 +1
+       const day = String(d.getDate()).padStart(2, '0');
+       const dateStr = `${year}-${month}-${day}`;
       timeData[dateStr] = {
         date: dateStr,
       };
@@ -187,8 +198,11 @@ const Dashboard = () => {
 
     // 填充实际数据
     data.forEach((item) => {
-      timeData[item.Day][item.ModelName] =
+      const data = timeData[item.Day];
+      if (data) {
+        data[item.ModelName] =
         item.PromptTokens + item.CompletionTokens;
+      }
     });
 
     return Object.values(timeData).sort((a, b) => a.date.localeCompare(b.date));


### PR DESCRIPTION


我已确认该 PR 已自测通过，相关截图如下：

复现步骤：在中国时区8点前请求一次接口（非测试），产生一条消费日志，然后进入总览就会报错，原因如下图所示

![PixPin_2025-03-10_00-25-46](https://github.com/user-attachments/assets/29b63300-9add-4600-98e9-7854b85c1bd7)


![PixPin_2025-03-10_00-13-26](https://github.com/user-attachments/assets/b6728a59-57f0-4571-bab7-44851b798198)

dailyData没有今天的日期对象，导致报异常，修复为手动提取年月日，规避时区问题