### PR TITLE
fix: 添加SKIP_TLS_VERIFY选项用于跳过TLS证书校验

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ graph LR
 28. `INITIAL_ROOT_ACCESS_TOKEN`：如果设置了该值，则在系统首次启动时会自动创建一个值为该环境变量的 root 用户创建系统管理令牌。
 29. `ENFORCE_INCLUDE_USAGE`：是否强制在 stream 模型下返回 usage，默认不开启，可选值为 `true` 和 `false`。
 30. `TEST_PROMPT`：测试模型时的用户 prompt，默认为 `Print your model name exactly and do not output without any other text.`。
+31. `SKIP_TLS_VERIFY`：是否在建立 HTTPS 连接时不验证服务器的 TLS 证书，默认不开启，可选值为 `true` 和 `false`。
 
 ### 命令行参数
 1. `--port <port_number>`: 指定服务器监听的端口号，默认为 `3000`。

--- a/common/client/init.go
+++ b/common/client/init.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"crypto/tls"
 	"fmt"
 	"github.com/songquanpeng/one-api/common/config"
 	"github.com/songquanpeng/one-api/common/logger"
@@ -14,6 +15,12 @@ var ImpatientHTTPClient *http.Client
 var UserContentRequestHTTPClient *http.Client
 
 func Init() {
+	// skip tls verify
+	unsafeTlsConfig := &tls.Config{InsecureSkipVerify: true}
+	if config.SkipTlsVerify {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = unsafeTlsConfig
+	}
+
 	if config.UserContentRequestProxy != "" {
 		logger.SysLog(fmt.Sprintf("using %s as proxy to fetch user content", config.UserContentRequestProxy))
 		proxyURL, err := url.Parse(config.UserContentRequestProxy)
@@ -39,6 +46,9 @@ func Init() {
 		}
 		transport = &http.Transport{
 			Proxy: http.ProxyURL(proxyURL),
+		}
+		if config.SkipTlsVerify {
+			transport.(*http.Transport).TLSClientConfig = unsafeTlsConfig
 		}
 	}
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -162,5 +162,7 @@ var RelayProxy = env.String("RELAY_PROXY", "")
 var UserContentRequestProxy = env.String("USER_CONTENT_REQUEST_PROXY", "")
 var UserContentRequestTimeout = env.Int("USER_CONTENT_REQUEST_TIMEOUT", 30)
 
+var SkipTlsVerify = env.Bool("SKIP_TLS_VERIFY", false)
+
 var EnforceIncludeUsage = env.Bool("ENFORCE_INCLUDE_USAGE", false)
 var TestPrompt = env.String("TEST_PROMPT", "Output only your specific model name with no additional text.")


### PR DESCRIPTION
## 问题描述

我们可能会使用一些自己运行的模型，然后API使用了https协议，但是证书是自签名的，这种情况下one-api就代理不了这个模型，页面点击“测试”会报错：错误：do request failed: Post "https://1.1.1.1:4430/v1/chat/completions": tls: failed to verify certificate: x509: cannot validate certificate for 1.1.1.1 because it doesn't contain any IP SANs

## 解决办法

提供一个SKIP_TLS_VERIFY选项，可用于全局跳过TLS证书校验，默认不开启

## 自测截图

![image](https://github.com/user-attachments/assets/d8dc584d-1756-4654-8a25-932981ebb7a1)


