### PR TITLE
fix: Compatible with Azure GPT4.1 series models, users do not need to manually delete the dot in the name when creating a deployment (#2235)

### DIFF
--- a/relay/adaptor/openai/adaptor.go
+++ b/relay/adaptor/openai/adaptor.go
@@ -45,7 +45,8 @@ func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
 		requestURL = fmt.Sprintf("%s?api-version=%s", requestURL, meta.Config.APIVersion)
 		task := strings.TrimPrefix(requestURL, "/v1/")
 		model_ := meta.ActualModelName
-		model_ = strings.Replace(model_, ".", "", -1)
+		// https://github.com/songquanpeng/one-api/issues/2235
+		// model_ = strings.Replace(model_, ".", "", -1)
 		//https://github.com/songquanpeng/one-api/issues/1191
 		// {your endpoint}/openai/deployments/{your azure_model}/chat/completions?api-version={api_version}
 		requestURL = fmt.Sprintf("/openai/deployments/%s/%s", model_, task)


### PR DESCRIPTION
close #2235

我已确认该 PR 已自测通过，相关截图如下：
模型配置&官方请求示例
![image](https://github.com/user-attachments/assets/cb7792d3-5486-4b16-ad41-1c98da5c156f)
测试结果
![image](https://github.com/user-attachments/assets/96e7cac6-e95e-4258-ac3a-130818dfa8ee)
