### PR TITLE
feat: 增加vertex embedding的支持，修改vertex的模型adapter匹配逻辑

### DIFF
--- a/relay/adaptor/gemini/main.go
+++ b/relay/adaptor/gemini/main.go
@@ -435,3 +435,17 @@ func EmbeddingHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStat
 	_, err = c.Writer.Write(jsonResponse)
 	return nil, &fullTextResponse.Usage
 }
+
+func EmbeddingResponseHandler(c *gin.Context, statusCode int, resp *openai.EmbeddingResponse) (*model.ErrorWithStatusCode, *model.Usage) {
+	jsonResponse, err := json.Marshal(resp)
+	if err != nil {
+		return openai.ErrorWrapper(err, "marshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(statusCode)
+	_, err = c.Writer.Write(jsonResponse)
+	if err != nil {
+		return openai.ErrorWrapper(err, "write_response_body_failed", http.StatusInternalServerError), nil
+	}
+	return nil, &resp.Usage
+}

--- a/relay/adaptor/gemini/model.go
+++ b/relay/adaptor/gemini/model.go
@@ -79,5 +79,5 @@ type ChatGenerationConfig struct {
 	MaxOutputTokens  int             `json:"maxOutputTokens,omitempty"`
 	CandidateCount   int             `json:"candidateCount,omitempty"`
 	StopSequences    []string        `json:"stopSequences,omitempty"`
-	ThinkingConfig   *ThinkingConfig `json:"thinkingConfig,omitempty"`
+	ThinkingConfig   *ThinkingConfig `json:"thinkingConfig"`
 }

--- a/relay/adaptor/gemini/model.go
+++ b/relay/adaptor/gemini/model.go
@@ -65,13 +65,19 @@ type ChatTools struct {
 	FunctionDeclarations any `json:"function_declarations,omitempty"`
 }
 
+type ThinkingConfig struct {
+	IncludeThoughts bool `json:"includeThoughts"`
+	ThinkingBudget  int  `json:"thinkingBudget"`
+}
+
 type ChatGenerationConfig struct {
-	ResponseMimeType string   `json:"responseMimeType,omitempty"`
-	ResponseSchema   any      `json:"responseSchema,omitempty"`
-	Temperature      *float64 `json:"temperature,omitempty"`
-	TopP             *float64 `json:"topP,omitempty"`
-	TopK             float64  `json:"topK,omitempty"`
-	MaxOutputTokens  int      `json:"maxOutputTokens,omitempty"`
-	CandidateCount   int      `json:"candidateCount,omitempty"`
-	StopSequences    []string `json:"stopSequences,omitempty"`
+	ResponseMimeType string          `json:"responseMimeType,omitempty"`
+	ResponseSchema   any             `json:"responseSchema,omitempty"`
+	Temperature      *float64        `json:"temperature,omitempty"`
+	TopP             *float64        `json:"topP,omitempty"`
+	TopK             float64         `json:"topK,omitempty"`
+	MaxOutputTokens  int             `json:"maxOutputTokens,omitempty"`
+	CandidateCount   int             `json:"candidateCount,omitempty"`
+	StopSequences    []string        `json:"stopSequences,omitempty"`
+	ThinkingConfig   *ThinkingConfig `json:"thinkingConfig,omitempty"`
 }

--- a/relay/adaptor/vertexai/adaptor.go
+++ b/relay/adaptor/vertexai/adaptor.go
@@ -61,12 +61,15 @@ func (a *Adaptor) GetChannelName() string {
 
 func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
 	suffix := ""
-	if strings.HasPrefix(meta.ActualModelName, "gemini") {
+	modelType := PredictModelType(meta.ActualModelName)
+	if modelType == VertexAIGemini {
 		if meta.IsStream {
 			suffix = "streamGenerateContent?alt=sse"
 		} else {
 			suffix = "generateContent"
 		}
+	} else if modelType == VertexAIEmbedding {
+		suffix = "predict"
 	} else {
 		if meta.IsStream {
 			suffix = "streamRawPredict?alt=sse"
@@ -114,4 +117,14 @@ func (a *Adaptor) ConvertImageRequest(request *model.ImageRequest) (any, error) 
 
 func (a *Adaptor) DoRequest(c *gin.Context, meta *meta.Meta, requestBody io.Reader) (*http.Response, error) {
 	return channelhelper.DoRequestHelper(a, c, meta, requestBody)
+}
+
+func PredictModelType(model string) VertexAIModelType {
+	if strings.HasPrefix(model, "gemini-") {
+		return VertexAIGemini
+	}
+	if strings.HasPrefix(model, "text-embedding") || strings.HasPrefix(model, "text-multilingual-embedding") {
+		return VertexAIEmbedding
+	}
+	return VertexAIClaude
 }

--- a/relay/adaptor/vertexai/adaptor.go
+++ b/relay/adaptor/vertexai/adaptor.go
@@ -78,13 +78,19 @@ func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
 		}
 	}
 
+	model := meta.ActualModelName
+	if strings.Contains(model, "?") {
+		// TODO: Maybe fix meta.ActualModelName?
+		model = strings.Split(model, "?")[0]
+	}
+
 	if meta.BaseURL != "" {
 		return fmt.Sprintf(
 			"%s/v1/projects/%s/locations/%s/publishers/google/models/%s:%s",
 			meta.BaseURL,
 			meta.Config.VertexAIProjectID,
 			meta.Config.Region,
-			meta.ActualModelName,
+			model,
 			suffix,
 		), nil
 	}
@@ -93,7 +99,7 @@ func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
 		meta.Config.Region,
 		meta.Config.VertexAIProjectID,
 		meta.Config.Region,
-		meta.ActualModelName,
+		model,
 		suffix,
 	), nil
 }

--- a/relay/adaptor/vertexai/embedding/adapter.go
+++ b/relay/adaptor/vertexai/embedding/adapter.go
@@ -1,0 +1,107 @@
+package vertexai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/songquanpeng/one-api/relay/adaptor/gemini"
+	"github.com/songquanpeng/one-api/relay/adaptor/openai"
+	model2 "github.com/songquanpeng/one-api/relay/adaptor/vertexai/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+
+	"github.com/songquanpeng/one-api/relay/meta"
+	"github.com/songquanpeng/one-api/relay/model"
+)
+
+var ModelList = []string{
+	"textembedding-gecko-multilingual@001", "text-multilingual-embedding-002",
+}
+
+type Adaptor struct {
+	model string
+	task  EmbeddingTaskType
+}
+
+var _ model2.InnerAIAdapter = (*Adaptor)(nil)
+
+func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+	inputs := request.ParseInput()
+	if len(inputs) == 0 {
+		return nil, errors.New("request is nil")
+	}
+	parts := strings.Split(request.Model, "|")
+	if len(parts) >= 2 {
+		a.task = EmbeddingTaskType(parts[1])
+	} else {
+		a.task = EmbeddingTaskTypeSemanticSimilarity
+	}
+	a.model = parts[0]
+	instances := make([]EmbeddingInstance, len(inputs))
+	for i, input := range inputs {
+		instances[i] = EmbeddingInstance{
+			Content:  input,
+			TaskType: a.task,
+		}
+	}
+
+	embeddingRequest := EmbeddingRequest{
+		Instances: instances,
+		Parameters: EmbeddingParams{
+			OutputDimensionality: request.Dimensions,
+		},
+	}
+
+	return embeddingRequest, nil
+}
+
+func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+	err, usage = EmbeddingHandler(c, a.model, resp)
+	return
+}
+
+func EmbeddingHandler(c *gin.Context, modelName string, resp *http.Response) (*model.ErrorWithStatusCode, *model.Usage) {
+	var vertexEmbeddingResponse EmbeddingResponse
+	responseBody, err := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return openai.ErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError), nil
+	}
+	if err != nil {
+		return openai.ErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError), nil
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return openai.ErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), nil
+	}
+	err = json.Unmarshal(responseBody, &vertexEmbeddingResponse)
+	if err != nil {
+		return openai.ErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+
+	openaiResp := &openai.EmbeddingResponse{
+		Model: modelName,
+		Data:  make([]openai.EmbeddingResponseItem, 0, len(vertexEmbeddingResponse.Predictions)),
+		Usage: model.Usage{
+			TotalTokens: 0,
+		},
+	}
+
+	for i, pred := range vertexEmbeddingResponse.Predictions {
+		openaiResp.Data = append(openaiResp.Data, openai.EmbeddingResponseItem{
+			Index:     i,
+			Embedding: pred.Embeddings.Values,
+		})
+	}
+
+	for _, pred := range vertexEmbeddingResponse.Predictions {
+		openaiResp.Usage.TotalTokens += pred.Embeddings.Statistics.TokenCount
+	}
+
+	return gemini.EmbeddingResponseHandler(c, resp.StatusCode, openaiResp)
+}

--- a/relay/adaptor/vertexai/embedding/adapter.go
+++ b/relay/adaptor/vertexai/embedding/adapter.go
@@ -23,7 +23,6 @@ var ModelList = []string{
 }
 
 type Adaptor struct {
-	model string
 }
 
 var _ model2.InnerAIAdapter = (*Adaptor)(nil)
@@ -52,8 +51,7 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 	if len(inputs) == 0 {
 		return nil, errors.New("request is nil")
 	}
-	modelName, modelTaskType := a.parseEmbeddingTaskType(request.Model)
-	a.model = modelName
+	_, modelTaskType := a.parseEmbeddingTaskType(request.Model)
 	instances := make([]EmbeddingInstance, len(inputs))
 	for i, input := range inputs {
 		instances[i] = EmbeddingInstance{
@@ -73,7 +71,11 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 }
 
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
-	err, usage = EmbeddingHandler(c, a.model, resp)
+	modelName := ""
+	if meta != nil {
+		modelName = meta.ActualModelName
+	}
+	err, usage = EmbeddingHandler(c, modelName, resp)
 	return
 }
 

--- a/relay/adaptor/vertexai/embedding/model.go
+++ b/relay/adaptor/vertexai/embedding/model.go
@@ -1,0 +1,45 @@
+package vertexai
+
+type EmbeddingTaskType string
+
+const (
+	EmbeddingTaskTypeRetrievalQuery     EmbeddingTaskType = "RETRIEVAL_QUERY"
+	EmbeddingTaskTypeRetrievalDocument  EmbeddingTaskType = "RETRIEVAL_DOCUMENT"
+	EmbeddingTaskTypeSemanticSimilarity EmbeddingTaskType = "SEMANTIC_SIMILARITY"
+	EmbeddingTaskTypeClassification     EmbeddingTaskType = "CLASSIFICATION"
+	EmbeddingTaskTypeClustering         EmbeddingTaskType = "CLUSTERING"
+	EmbeddingTaskTypeQuestionAnswering  EmbeddingTaskType = "QUESTION_ANSWERING"
+	EmbeddingTaskTypeFactVerification   EmbeddingTaskType = "FACT_VERIFICATION"
+	EmbeddingTaskTypeCodeRetrievalQuery EmbeddingTaskType = "CODE_RETRIEVAL_QUERY"
+)
+
+type EmbeddingRequest struct {
+	Instances  []EmbeddingInstance `json:"instances"`
+	Parameters EmbeddingParams     `json:"parameters"`
+}
+
+type EmbeddingInstance struct {
+	Content  string            `json:"content"`
+	TaskType EmbeddingTaskType `json:"task_type,omitempty"`
+	Title    string            `json:"title,omitempty"`
+}
+
+type EmbeddingParams struct {
+	AutoTruncate         bool `json:"autoTruncate,omitempty"`
+	OutputDimensionality int  `json:"outputDimensionality,omitempty"`
+	// Texts                []string `json:"texts,omitempty"`
+}
+
+type EmbeddingResponse struct {
+	Predictions []struct {
+		Embeddings EmbeddingData `json:"embeddings"`
+	} `json:"predictions"`
+}
+
+type EmbeddingData struct {
+	Statistics struct {
+		Truncated  bool `json:"truncated"`
+		TokenCount int  `json:"token_count"`
+	} `json:"statistics"`
+	Values []float64 `json:"values"`
+}

--- a/relay/adaptor/vertexai/embedding/model.go
+++ b/relay/adaptor/vertexai/embedding/model.go
@@ -3,6 +3,7 @@ package vertexai
 type EmbeddingTaskType string
 
 const (
+	EmbeddingTaskTypeNone               EmbeddingTaskType = ""
 	EmbeddingTaskTypeRetrievalQuery     EmbeddingTaskType = "RETRIEVAL_QUERY"
 	EmbeddingTaskTypeRetrievalDocument  EmbeddingTaskType = "RETRIEVAL_DOCUMENT"
 	EmbeddingTaskTypeSemanticSimilarity EmbeddingTaskType = "SEMANTIC_SIMILARITY"

--- a/relay/adaptor/vertexai/gemini/adapter.go
+++ b/relay/adaptor/vertexai/gemini/adapter.go
@@ -57,7 +57,17 @@ func (a *Adaptor) parseGeminiChatGenerationThinking(model string) (string, *gemi
 			}
 		}
 	}
-	return modelName, thinkingConfig
+	if strings.HasPrefix(modelName, "gemini-2.5") {
+		// 目前2.5的模型支持传递thinking config，且默认开启了thinking，不希望进入thinking模式需要显式传递thinkingConfig来关闭
+		return modelName, thinkingConfig
+	} else {
+		// 其他模型暂时不支持
+		if thinkingConfig != nil && (thinkingConfig.IncludeThoughts || thinkingConfig.ThinkingBudget > 0) {
+			// 为了后续一旦有其他模型支持了thinking，这里指定可以指定参数开启
+			return modelName, thinkingConfig
+		}
+		return modelName, nil
+	}
 }
 
 func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error) {

--- a/relay/adaptor/vertexai/gemini/adapter.go
+++ b/relay/adaptor/vertexai/gemini/adapter.go
@@ -41,16 +41,16 @@ func (a *Adaptor) parseGeminiChatGenerationThinking(model string) (string, *gemi
 		_modelName := parts[0]
 		if len(parts) >= 2 {
 			modelOptions, err := url.ParseQuery(parts[1])
-			if err != nil && modelOptions != nil {
+			if err == nil && modelOptions != nil {
 				modelName = _modelName
-				enableThinking := modelOptions.Has("thinking")
-				if enableThinking {
-					thinkingConfig.IncludeThoughts = true
+				hasThinkingFlag := modelOptions.Has("thinking")
+				if hasThinkingFlag {
+					thinkingConfig.IncludeThoughts = modelOptions.Get("thinking") == "1"
 				}
 				thinkingBudget := modelOptions.Get("thinking_budget")
 				if thinkingBudget != "" {
 					thinkingBudgetInt, err := strconv.Atoi(thinkingBudget)
-					if err != nil {
+					if err == nil {
 						thinkingConfig.ThinkingBudget = thinkingBudgetInt
 					}
 				}

--- a/relay/adaptor/vertexai/model/model.go
+++ b/relay/adaptor/vertexai/model/model.go
@@ -1,0 +1,13 @@
+package model
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/songquanpeng/one-api/relay/meta"
+	"github.com/songquanpeng/one-api/relay/model"
+	"net/http"
+)
+
+type InnerAIAdapter interface {
+	ConvertRequest(c *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error)
+	DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode)
+}


### PR DESCRIPTION
Feature:
1. 改动VertexAI的GetAdaptor逻辑，default增加模型adapter的逻辑，便于适配后续新模型产生
2. 增加VertexAI的Embedding的adapter，支持VertexAI的embedding api
3. Vertex中的Embedding模型支持微调任务类型，比如想使用“RETRIEVAL_DOCUMENT”类型的微调任务，可以选择模型名称填写`text-multilingual-embedding-002?task_type=RETRIEVAL_DOCUMENT`
> https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api#request_body
4. 最新的`gemini-2.5-flash-preview-04-17`模型默认会开启Thinking模式，支持传递`?thinking=1&thinking_budget=500`来控制
> https://cloud.google.com/vertex-ai/generative-ai/docs/thinking




我已确认该 PR 已自测通过，相关截图如下：


![image](https://github.com/user-attachments/assets/76f78019-8020-4973-bb82-e2f9b82c061c)
![image](https://github.com/user-attachments/assets/4cc0638a-8553-49d2-b438-b87f7d7d3153)
![image](https://github.com/user-attachments/assets/1b5105b2-5cb1-4227-8199-4f053ce5a615)

