### PR TITLE
fix: preserve extra request fields when model name is remapped

### DIFF
--- a/relay/controller/text.go
+++ b/relay/controller/text.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/songquanpeng/one-api/common"
 	"github.com/songquanpeng/one-api/common/config"
 	"github.com/songquanpeng/one-api/common/logger"
 	"github.com/songquanpeng/one-api/relay"
@@ -90,11 +91,28 @@ func RelayTextHelper(c *gin.Context) *model.ErrorWithStatusCode {
 func getRequestBody(c *gin.Context, meta *meta.Meta, textRequest *model.GeneralOpenAIRequest, adaptor adaptor.Adaptor) (io.Reader, error) {
 	if !config.EnforceIncludeUsage &&
 		meta.APIType == apitype.OpenAI &&
-		meta.OriginModelName == meta.ActualModelName &&
 		meta.ChannelType != channeltype.Baichuan &&
 		meta.ForcedSystemPrompt == "" {
-		// no need to convert request for openai
-		return c.Request.Body, nil
+		if meta.OriginModelName == meta.ActualModelName {
+			// no need to convert request for openai
+			return c.Request.Body, nil
+		}
+		// Only the model name was remapped; patch the original body so that any
+		// extra fields sent by the client (e.g. enable_search, extra_body params)
+		// are preserved instead of being dropped by the struct round-trip.
+		if originalBody, err := common.GetRequestBody(c); err == nil {
+			var bodyMap map[string]json.RawMessage
+			if jsonErr := json.Unmarshal(originalBody, &bodyMap); jsonErr == nil {
+				if modelJSON, marshalErr := json.Marshal(meta.ActualModelName); marshalErr == nil {
+					bodyMap["model"] = json.RawMessage(modelJSON)
+					if patchedBody, marshalErr := json.Marshal(bodyMap); marshalErr == nil {
+						logger.Debugf(c.Request.Context(), "patched model in request body: %s -> %s", meta.OriginModelName, meta.ActualModelName)
+						return bytes.NewBuffer(patchedBody), nil
+					}
+				}
+			}
+		}
+		// fallthrough to full conversion if patching fails
 	}
 
 	// get request body


### PR DESCRIPTION
Fixes #2295

## Problem

When a channel has model mapping configured (e.g. `{"hy-dsc": "deepseek-v3-0324"}`), relay/controller/text.go was re-serialising the request from the parsed `GeneralOpenAIRequest` struct.  Any unknown fields sent by the client — such as `enable_search`, `enable_thinking`, or other provider-specific params added via the OpenAI Python SDK's `extra_body` mechanism — were silently dropped in that struct → JSON round-trip, so they never reached the upstream provider.

Without the fix, a call like:

```python
client.chat.completions.create(
    model="hy-dsc",
    messages=[...],
    extra_body={"enable_search": True},
)
```

would strip `enable_search` from the forwarded body, breaking Tencent Cloud DeepSeek's web-search feature and similar provider extensions.

## Solution

For OpenAI-type channels where the only transformation needed is a model name substitution (no forced system prompt, no `EnforceIncludeUsage`, not Baichuan), patch the `model` field directly in the cached raw request body instead of going through a full parse → marshal cycle.  This preserves all extra/unknown fields so they reach the upstream provider unchanged.  The code falls back to the existing full-conversion path if the raw body is unavailable or unparseable.

## Testing

- Configured a channel with model mapping `{"alias-model": "real-model"}`.
- Sent a request with `model=alias-model` and an extra field `enable_search=true` in the body.
- Verified the upstream received `model=real-model` **and** `enable_search=true`.
- Verified that requests without model mapping still pass through the body untouched (existing path unchanged).
- Verified that requests requiring full conversion (forced system prompt, Baichuan channels, `EnforceIncludeUsage`) still use the full conversion path.