### PR TITLE
refactor: remove unused variable newChannelId2channel in InitChannelCache

### DIFF
--- a/model/cache.go
+++ b/model/cache.go
@@ -171,12 +171,8 @@ var group2model2channels map[string]map[string][]*Channel
 var channelSyncLock sync.RWMutex
 
 func InitChannelCache() {
-	newChannelId2channel := make(map[int]*Channel)
 	var channels []*Channel
 	DB.Where("status = ?", ChannelStatusEnabled).Find(&channels)
-	for _, channel := range channels {
-		newChannelId2channel[channel.Id] = channel
-	}
 	var abilities []*Ability
 	DB.Find(&abilities)
 	groups := make(map[string]bool)


### PR DESCRIPTION
Fixes #2321

## Problem

In `model/cache.go`, the `InitChannelCache` function declares and populates a `newChannelId2channel` map but never reads from it afterward. This is dead code — the variable serves no purpose.

```go
// Before: allocated and filled but never used
newChannelId2channel := make(map[int]*Channel)
for _, channel := range channels {
    newChannelId2channel[channel.Id] = channel
}
```

## Solution

Remove the unused `newChannelId2channel` variable and its associated loop iteration. The remaining logic (building `newGroup2model2channels` and syncing it to `group2model2channels`) is unchanged.

## Testing

No behaviour change — the removed code had no effect. Existing tests continue to pass.