### PR TITLE
feat: wire MiniMax text to speech relay

### DIFF
--- a/relay/adaptor/minimax/constants.go
+++ b/relay/adaptor/minimax/constants.go
@@ -3,6 +3,14 @@ package minimax
 // https://www.minimaxi.com/document/guides/chat-model/V2?id=65e0736ab2845de20908e2dd
 
 var ModelList = []string{
+	"speech-2.8-hd",
+	"speech-2.8-turbo",
+	"speech-2.6-hd",
+	"speech-2.6-turbo",
+	"speech-02-hd",
+	"speech-02-turbo",
+	"speech-01-hd",
+	"speech-01-turbo",
 	"abab6.5-chat",
 	"abab6.5s-chat",
 	"abab6-chat",

--- a/relay/adaptor/minimax/main.go
+++ b/relay/adaptor/minimax/main.go
@@ -2,6 +2,8 @@ package minimax
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/songquanpeng/one-api/relay/meta"
 	"github.com/songquanpeng/one-api/relay/relaymode"
 )
@@ -9,6 +11,13 @@ import (
 func GetRequestURL(meta *meta.Meta) (string, error) {
 	if meta.Mode == relaymode.ChatCompletions {
 		return fmt.Sprintf("%s/v1/text/chatcompletion_v2", meta.BaseURL), nil
+	}
+	if meta.Mode == relaymode.AudioSpeech {
+		baseURL := strings.TrimSuffix(strings.TrimRight(meta.BaseURL, "/"), "/v1")
+		if strings.Contains(baseURL, "api.minimax.chat") {
+			baseURL = strings.Replace(baseURL, "api.minimax.chat", "api.minimax.io", 1)
+		}
+		return fmt.Sprintf("%s/v1/t2a_v2", baseURL), nil
 	}
 	return "", fmt.Errorf("unsupported relay mode %d for minimax", meta.Mode)
 }

--- a/relay/controller/audio.go
+++ b/relay/controller/audio.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,6 +28,106 @@ import (
 	relaymodel "github.com/songquanpeng/one-api/relay/model"
 	"github.com/songquanpeng/one-api/relay/relaymode"
 )
+
+type minimaxSpeechRequest struct {
+	Model        string              `json:"model"`
+	Text         string              `json:"text"`
+	Stream       bool                `json:"stream"`
+	OutputFormat string              `json:"output_format"`
+	VoiceSetting minimaxVoiceSetting `json:"voice_setting"`
+	AudioSetting minimaxAudioSetting `json:"audio_setting"`
+}
+
+type minimaxVoiceSetting struct {
+	VoiceID string  `json:"voice_id"`
+	Speed   float64 `json:"speed"`
+}
+
+type minimaxAudioSetting struct {
+	SampleRate int    `json:"sample_rate"`
+	Bitrate    int    `json:"bitrate"`
+	Format     string `json:"format"`
+	Channel    int    `json:"channel"`
+}
+
+type minimaxSpeechResponse struct {
+	Data struct {
+		Audio string `json:"audio"`
+	} `json:"data"`
+	BaseResp struct {
+		StatusCode int    `json:"status_code"`
+		StatusMsg  string `json:"status_msg"`
+	} `json:"base_resp"`
+}
+
+func buildMinimaxSpeechRequest(ttsRequest openai.TextToSpeechRequest) ([]byte, string, error) {
+	format := strings.ToLower(ttsRequest.ResponseFormat)
+	if format == "" {
+		format = "mp3"
+	}
+	switch format {
+	case "mp3", "wav", "flac", "pcm":
+	default:
+		return nil, "", fmt.Errorf("unsupported audio response format %q", format)
+	}
+	speed := ttsRequest.Speed
+	if speed == 0 {
+		speed = 1
+	}
+	request := minimaxSpeechRequest{
+		Model:        ttsRequest.Model,
+		Text:         ttsRequest.Input,
+		Stream:       false,
+		OutputFormat: "hex",
+		VoiceSetting: minimaxVoiceSetting{VoiceID: ttsRequest.Voice, Speed: speed},
+		AudioSetting: minimaxAudioSetting{SampleRate: 32000, Bitrate: 128000, Format: format, Channel: 1},
+	}
+	body, err := json.Marshal(request)
+	return body, format, err
+}
+
+func decodeMinimaxSpeechResponse(body []byte) ([]byte, error) {
+	var response minimaxSpeechResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+	if response.BaseResp.StatusCode != 0 {
+		return nil, fmt.Errorf("upstream speech error %d: %s", response.BaseResp.StatusCode, response.BaseResp.StatusMsg)
+	}
+	if response.Data.Audio == "" {
+		return nil, errors.New("upstream speech response did not include audio")
+	}
+	audio := strings.TrimSpace(response.Data.Audio)
+	if decoded, err := hex.DecodeString(audio); err == nil {
+		return decoded, nil
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(audio); err == nil {
+		return decoded, nil
+	}
+	return nil, errors.New("upstream speech audio is not valid hex or base64")
+}
+
+func minimaxSpeechURL(baseURL string) string {
+	baseURL = strings.TrimRight(baseURL, "/")
+	baseURL = strings.TrimSuffix(baseURL, "/v1")
+	if strings.Contains(baseURL, "api.minimax.chat") {
+		baseURL = strings.Replace(baseURL, "api.minimax.chat", "api.minimax.io", 1)
+	}
+	return baseURL + "/v1/t2a_v2"
+}
+
+func audioContentType(format string) string {
+	switch format {
+	case "wav":
+		return "audio/wav"
+	case "flac":
+		return "audio/flac"
+	case "pcm":
+		return "audio/L16"
+	default:
+		return "audio/mpeg"
+	}
+}
 
 func RelayAudioHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatusCode {
 	ctx := c.Request.Context()
@@ -140,6 +242,19 @@ func RelayAudioHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 	}
 	c.Request.Body = io.NopCloser(bytes.NewBuffer(requestBody.Bytes()))
 	responseFormat := c.DefaultPostForm("response_format", "json")
+	if relayMode == relaymode.AudioSpeech && ttsRequest.ResponseFormat != "" {
+		responseFormat = strings.ToLower(ttsRequest.ResponseFormat)
+	}
+	if relayMode == relaymode.AudioSpeech && channelType == channeltype.Minimax {
+		ttsRequest.Model = audioModel
+		requestBodyBytes, format, requestErr := buildMinimaxSpeechRequest(ttsRequest)
+		if requestErr != nil {
+			return openai.ErrorWrapper(requestErr, "invalid_request_error", http.StatusBadRequest)
+		}
+		requestBody = bytes.NewBuffer(requestBodyBytes)
+		responseFormat = format
+		fullRequestURL = minimaxSpeechURL(baseURL)
+	}
 
 	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
@@ -157,6 +272,10 @@ func RelayAudioHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 	}
 	req.Header.Set("Content-Type", c.Request.Header.Get("Content-Type"))
 	req.Header.Set("Accept", c.Request.Header.Get("Accept"))
+	if relayMode == relaymode.AudioSpeech && channelType == channeltype.Minimax {
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+	}
 
 	resp, err := client.HTTPClient.Do(req)
 	if err != nil {
@@ -213,15 +332,38 @@ func RelayAudioHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 	if resp.StatusCode != http.StatusOK {
 		return RelayErrorHandler(resp)
 	}
+	for k, v := range resp.Header {
+		c.Writer.Header().Set(k, v[0])
+	}
+	if relayMode == relaymode.AudioSpeech && channelType == channeltype.Minimax {
+		responseBody, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return openai.ErrorWrapper(readErr, "read_response_body_failed", http.StatusInternalServerError)
+		}
+		audio, decodeErr := decodeMinimaxSpeechResponse(responseBody)
+		if decodeErr != nil {
+			return openai.ErrorWrapper(decodeErr, "invalid_response", http.StatusBadGateway)
+		}
+		succeed = true
+		quotaDelta := quota - preConsumedQuota
+		defer func(ctx context.Context) {
+			go billing.PostConsumeQuota(ctx, tokenId, quotaDelta, quota, userId, channelId, modelRatio, groupRatio, audioModel, tokenName)
+		}(c.Request.Context())
+		c.Writer.Header().Set("Content-Type", audioContentType(responseFormat))
+		c.Writer.Header().Set("Content-Length", fmt.Sprintf("%d", len(audio)))
+		c.Writer.WriteHeader(resp.StatusCode)
+		_, err = c.Writer.Write(audio)
+		if err != nil {
+			return openai.ErrorWrapper(err, "copy_response_body_failed", http.StatusInternalServerError)
+		}
+		return nil
+	}
 	succeed = true
 	quotaDelta := quota - preConsumedQuota
 	defer func(ctx context.Context) {
 		go billing.PostConsumeQuota(ctx, tokenId, quotaDelta, quota, userId, channelId, modelRatio, groupRatio, audioModel, tokenName)
 	}(c.Request.Context())
-
-	for k, v := range resp.Header {
-		c.Writer.Header().Set(k, v[0])
-	}
 	c.Writer.WriteHeader(resp.StatusCode)
 
 	_, err = io.Copy(c.Writer, resp.Body)

--- a/relay/controller/audio_minimax_test.go
+++ b/relay/controller/audio_minimax_test.go
@@ -1,0 +1,61 @@
+package controller
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/songquanpeng/one-api/relay/adaptor/openai"
+)
+
+func TestBuildMinimaxSpeechRequest(t *testing.T) {
+	body, format, err := buildMinimaxSpeechRequest(openai.TextToSpeechRequest{
+		Model:          "speech-2.8-hd",
+		Input:          "hello",
+		Voice:          "female-shaonv",
+		ResponseFormat: "wav",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if format != "wav" {
+		t.Fatalf("format = %q", format)
+	}
+	var request minimaxSpeechRequest
+	if err := json.Unmarshal(body, &request); err != nil {
+		t.Fatal(err)
+	}
+	if request.Model != "speech-2.8-hd" || request.Text != "hello" || request.VoiceSetting.VoiceID != "female-shaonv" || request.VoiceSetting.Speed != 1 || request.AudioSetting.Format != "wav" || request.OutputFormat != "hex" {
+		t.Fatalf("unexpected request: %+v", request)
+	}
+}
+
+func TestDecodeMinimaxSpeechResponse(t *testing.T) {
+	hexAudio := hex.EncodeToString([]byte("audio"))
+	decoded, err := decodeMinimaxSpeechResponse([]byte(`{"data":{"audio":"` + hexAudio + `"},"base_resp":{"status_code":0}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(decoded) != "audio" {
+		t.Fatalf("decoded = %q", decoded)
+	}
+
+	base64Audio := base64.StdEncoding.EncodeToString([]byte("audio"))
+	decoded, err = decodeMinimaxSpeechResponse([]byte(`{"data":{"audio":"` + base64Audio + `"},"base_resp":{"status_code":0}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(decoded) != "audio" {
+		t.Fatalf("decoded = %q", decoded)
+	}
+}
+
+func TestMinimaxSpeechURL(t *testing.T) {
+	if got := minimaxSpeechURL("https://api.minimax.chat"); got != "https://api.minimax.io/v1/t2a_v2" {
+		t.Fatalf("url = %q", got)
+	}
+	if got := minimaxSpeechURL("https://api.minimax.io/v1/"); got != "https://api.minimax.io/v1/t2a_v2" {
+		t.Fatalf("url = %q", got)
+	}
+}

--- a/web/berry/src/views/Channel/type/Config.js
+++ b/web/berry/src/views/Channel/type/Config.js
@@ -147,7 +147,19 @@ const typeConfig = {
   },
   27: {
     input: {
-      models: ['abab5.5s-chat', 'abab5.5-chat', 'abab6-chat']
+      models: [
+        'speech-2.8-hd',
+        'speech-2.8-turbo',
+        'speech-2.6-hd',
+        'speech-2.6-turbo',
+        'speech-02-hd',
+        'speech-02-turbo',
+        'speech-01-hd',
+        'speech-01-turbo',
+        'abab5.5s-chat',
+        'abab5.5-chat',
+        'abab6-chat'
+      ]
     },
     modelGroup: 'minimax'
   },


### PR DESCRIPTION
Reason: MiniMax speech support was missing from the OpenAI-compatible audio speech relay.

This change routes MiniMax speech requests to `/v1/t2a_v2`, maps OpenAI text-to-speech fields to MiniMax `voice_setting` and `audio_setting`, and decodes the returned audio payload for the client. It also registers the available speech models in the MiniMax model lists.

Checks:
- `GOPROXY=off go test ./relay/controller ./relay/adaptor/minimax`
- `git diff --check`
- Secret scan completed with no matches.
